### PR TITLE
Python: Removing the bit about commas and exceptions.

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -283,12 +283,6 @@ try:
 except IndexError as e:
     pass    # Pass is just a no-op. Usually you would do recovery here.
 
-# Works for Python 2.7 and down:
-try:
-    raise IndexError("This is an index error")
-except IndexError, e: # No "as", comma instead
-    pass
-
 
 ####################################################
 ## 4. Functions


### PR DESCRIPTION
I don't imagine anyone starting out is using Python <2.6, and having a section that says if you're using Python 2.6+ use the `as` but if you're using Python <=2.7 use the `,` is confusing.
- What happens if you're using Python 2.6 or Python 2.7? Which do you use? (`as`, but it isn't clear).

I decided to remove it entirely to avoid confusion.
