### PR TITLE
Remove mentions of array

### DIFF
--- a/haskell.html.markdown
+++ b/haskell.html.markdown
@@ -152,10 +152,10 @@ fib x = fib (x - 1) + fib (x - 2)
 -- Pattern matching on tuples:
 foo (x, y) = (x + 1, y + 2)
 
--- Pattern matching on arrays. Here `x` is the first element
--- in the array, and `xs` is the rest of the array. We can write
+-- Pattern matching on lists. Here `x` is the first element
+-- in the list, and `xs` is the rest of the list. We can write
 -- our own map function:
-myMap func [x] = [func x]
+myMap func [] = []
 myMap func (x:xs) = func x:(myMap func xs)
 
 -- Anonymous functions are created with a backslash followed by
@@ -164,7 +164,7 @@ myMap (\x -> x + 2) [1..5] -- [3, 4, 5, 6, 7]
 
 -- using fold (called `inject` in some languages) with an anonymous
 -- function. foldl1 means fold left, and use the first value in the
--- array as the initial value for the accumulator.
+-- list as the initial value for the accumulator.
 foldl1 (\acc x -> acc + x) [1..5] -- 15
 
 ----------------------------------------------------


### PR DESCRIPTION
Since all the functions work with lists, calling them arrays is inaccurate. This commit also updates `myMap` function so that it works on an empty list as well as resolves ambiguity about `x` from comment.
