### PR TITLE
Python - Minor Fix

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -328,7 +328,7 @@ def add(x, y):
     return x + y    # Return values with a return statement
 
 # Calling functions with parameters
-add(5, 6) #=> 11 and prints out "x is 5 and y is 6"
+add(5, 6) #=> prints out "x is 5 and y is 6" and 11.
 # Another way to call functions is with keyword arguments
 add(y=6, x=5)   # Keyword arguments can arrive in any order.
 


### PR DESCRIPTION
Just a minor fix for the Python 2 tutorial.

The function _add_ prints  "x is 5 and y is 6" before the _return_ and not vice-versa
