### PR TITLE
Ruby: nil != false

### DIFF
--- a/ruby.html.markdown
+++ b/ruby.html.markdown
@@ -43,16 +43,17 @@ false.class #=> FalseClass
 1 == 1 #=> true
 2 == 1 #=> false
 
-# apart from false itself, nil is the only other 'falsey' value
-
-nil == false #=> true
-0 == false #=> false
-
 # Inequality
 1 != 1 #=> false
 2 != 1 #=> true
 !true  #=> false
 !false #=> true
+
+# apart from false itself, nil is the only other 'falsey' value
+
+!nil   #=> true
+!false #=> true
+!0     #=> false
 
 # More comparisons
 1 < 10 #=> true


### PR DESCRIPTION
Instead of saying `nil == false` (which is incorrect), show that negating `nil` and `false` produces `true`. Negating anything else will produce `false`.
