### PR TITLE
Spelling error one of the comments in erlang.html.markdown

### DIFF
--- a/erlang.html.markdown
+++ b/erlang.html.markdown
@@ -6,7 +6,7 @@ filename: learnerlang.erl
 ---
 
 ```erlang
-% Percent sign starts an one-line comment.
+% Percent sign starts a one-line comment.
 
 %% Two percent characters shall be used to comment functions.
 


### PR DESCRIPTION
% Percent sign starts an one-line comment.
should be:
% Percent sign starts a one-line comment.
