### PR TITLE
Add ruby-ecosystem to tools section

### DIFF
--- a/ruby-ecosystem.html.markdown
+++ b/ruby-ecosystem.html.markdown
@@ -120,6 +120,17 @@ Bundler will notify you of the conflict. This becomes extremely helpful as many
 gems refer to other gems (which refer to other gems), which can form a large
 dependency graph to resolve.
 
+# Testing
+
+Testing is a large of ruby culture. Ruby comes with its own Unit-style testing
+framework called minitest (Or TestUnit for ruby version 1.8.x). There are many
+testing libraries with different goals.
+
+* TestUnit - Ruby 1.8's built-in "Unit-style" testing framework
+* minitest - Ruby 1.9/2.0's built-in testing framework
+* RSpec - A testing framework that focuses on expressivity
+* Cucumber - A BDD testing framework that parses Gherkin formatted tests
+
 ## Be Nice
 
 The ruby community takes pride in being an open, diverse, welcoming community.


### PR DESCRIPTION
This request is based on this tweet "conversation" between Adam and me: https://twitter.com/jonsmock/status/365460828415197184

Learning other languages, I've always wanted a brief, semi-opinionated view into that language's ecosystem. Sort of a lay of the land and a gut-feel for what is used and reliable in that ecosystem. Basic things like interpreter version can be confusing as an outsider with no history or context to draw upon. Having at least a 10,000 ft view can save a huge amount of time in getting up and running.

Examples:
- What is the deal with Python 2 vs. 3?
- What is the difference between Haskell and Haskell Platform?
- What do people use to test their Clojure apps?

I've tried to touch on some of these kinds of questions for Ruby here. Certain points could be debated, and I'm sure I left some details out (for instance, I just realized I didn't talk about testing at all, a big part of ruby culture). Hopefully this is a good start and conveys the spirit of the idea. I hope others improve it and fix inaccuracies.

Hopefully the formatting is ok!! :-P

EDIT: I added a small testing section, but it is very shaky, because I have to get to work!
