### PR TITLE
[Ruby-fr] Fix length of comments and french syntax

### DIFF
--- a/fr-fr/ruby-fr.html.markdown
+++ b/fr-fr/ruby-fr.html.markdown
@@ -201,8 +201,8 @@ end
 # et passez lui un bloc de code.
 # Un bloc de code est un ensemble d'instructions
 # que vous pouvez passer à une methode comme "each".
-# Les blocs sont similaires aux lambdas, les fonctions anonymes
-# ou les closures dans d'autres langages.
+# Les blocs sont similaires aux lambdas, aux fonctions anonymes
+# ou encore aux closures dans d'autres langages.
 #
 # La méthode "each" exécute le bloc de code
 # pour chaque élément de l'intervalle d'éléments.


### PR DESCRIPTION
Hi,

Some comments exceed the block of code [Ruby-fr](http://learnxinyminutes.com/docs/fr-fr/ruby-fr/). Therefore, I've split the comments in two lines.

But for the interpolation, I can't split otherwise, we lost the syntax highlighting. 

Picture of the exceeding: 
![Comments](https://f.cloud.github.com/assets/309354/979591/4a775f8a-0718-11e3-8bfe-501d0c76e0f1.png)
![Interpolation](https://f.cloud.github.com/assets/309354/979595/8db91b3a-0718-11e3-8a1a-fcfeb2c6bd30.png)

And I've fixed a french syntax error.

Thanks.
