### PR TITLE
The case statement in Bash is incorrect

### DIFF
--- a/bash.html.markdown
+++ b/bash.html.markdown
@@ -73,12 +73,11 @@ ls -l | grep "\.txt"
 echo "There are $(ls | wc -l) items here."
 
 # Bash uses a case statement that works similarily to switch in Java and C++:
-case "$VARIABLE"
-in
+case "$VARIABLE" in 
     #List patterns for the conditions you want to meet
-    0) echo "There is a zero."
-    1) echo "There is a one."
-    *) echo "It is not null."
+    0) echo "There is a zero.";;
+    1) echo "There is a one.";;
+    *) echo "It is not null.";;
 esac
 
 #For loops iterate for as many arguments given:


### PR DESCRIPTION
![Case Statement Error](https://f.cloud.github.com/assets/1726038/1062245/b3d0d8aa-1233-11e3-99ab-cc0db7ade74f.png)
In the case statement, the "in" keyword should be on the same line as case $VARIABLE. Also, ;; should be present at the end of each command. Shell executes all statements up to the two semicolons that are next to each other.
![Case Statement Error-Free](https://f.cloud.github.com/assets/1726038/1062248/fa8b488e-1233-11e3-989b-13d8c988b8fa.png)
