### PR TITLE
Corrected comment: utf-8 → unicode

### DIFF
--- a/go.html.markdown
+++ b/go.html.markdown
@@ -71,7 +71,7 @@ func learnTypes() {
 can include line breaks.` // same string type
 
     // non-ASCII literal.  Go source is UTF-8.
-    g := 'Σ' // rune type, an alias for uint32, holds a UTF-8 code point
+    g := 'Σ' // rune type, an alias for uint32, holds a unicode code point
 
     f := 3.14195 // float64, an IEEE-754 64-bit floating point number
     c := 3 + 4i  // complex128, represented internally with two float64s


### PR DESCRIPTION
Runes hold the raw unicode code point, not utf-8. Storing utf-8 inside of a uint32 would be highly inefficient. Runes are essentially utf-32.
