### PR TITLE
[javascript/en] Be consistent with PascalCasing of constructors

### DIFF
--- a/javascript.html.markdown
+++ b/javascript.html.markdown
@@ -357,13 +357,13 @@ myObj.meaningOfLife; // = 43
 // Constructors have a property called prototype. This is *not* the prototype of
 // the constructor function itself; instead, it's the prototype that new objects
 // are given when they're created with that constructor and the new keyword.
-myConstructor.prototype = {
+MyConstructor.prototype = {
     myNumber: 5,
     getMyNumber: function(){
         return this.myNumber;
     }
 };
-var myNewObj2 = new myConstructor();
+var myNewObj2 = new MyConstructor();
 myNewObj2.getMyNumber(); // = 5
 myNewObj2.myNumber = 6
 myNewObj2.getMyNumber(); // = 6


### PR DESCRIPTION
As per common convention and all other examples I'd use PascalCase for the 2nd `MyConstructor`-example as well.
