### PR TITLE
[elixir/de-de] Fixes language identification in elixir-de

### DIFF
--- a/de-de/elixir-de.html.markdown
+++ b/de-de/elixir-de.html.markdown
@@ -5,7 +5,7 @@ contributors:
 translators:
     - ["Gregor Große-Bölting", "http://www.ideen-und-soehne.de"]
 filename: learnelixir-de.ex
-+lang: de-de
+lang: de-de
 ---
 
 Elixir ist eine moderne, funktionale Sprache für die Erlang VM. Sie ist voll 


### PR DESCRIPTION
I noticed there were two lines for 'elixir' on the website.  One was the German translation.

YAML frontmatter had a line that looks like it was mis-patched
(started with a `+`).  Removed the `+` so the translation is displayed
in the right place.
