### PR TITLE
[python/fr-fr] French translation typo in comments for slice syntax with omitted indexes

### DIFF
--- a/fr-fr/python-fr.html.markdown
+++ b/fr-fr/python-fr.html.markdown
@@ -156,9 +156,9 @@ li[4] # Lève un 'IndexError'
 # On peut accèder à des rangs de valeurs avec la syntaxe "slice"
 # (C'est un rang de type 'fermé/ouvert' pour les plus matheux)
 li[1:3] #=> [2, 4]
-# Sans spécifier de début de rang
+# Sans spécifier de fin de rang, on "saute" le début de la liste
 li[2:] #=> [4, 3]
-# Sans spécifier de fin de rang
+# Sans spécifier de début de rang, on "saute" la fin de la liste
 li[:3] #=> [1, 2, 4]
 
 # Retirer un élément spécifique dee la liste avec "del"


### PR DESCRIPTION
Translation typo in comments for slice syntax with omitted indexes:
"Omit the beginning" meant omit the beginning _of the list_ (not the beginning of the range)
"Omit the end" meant omit the end _of the list_ (not the end of the range)

Current french comments "Sans spécifier de début de rang"/"Sans spécifier de fin de rang" are misleading because they means "No range start given" and "No range end given" respectively.
