### PR TITLE
Corrects Array#[,] entry

### DIFF
--- a/ruby.html.markdown
+++ b/ruby.html.markdown
@@ -139,8 +139,8 @@ array.[] 12 #=> nil
 # From the end
 array[-1] #=> 5
 
-# With a start and end index
-array[2, 4] #=> [3, 4, 5]
+# With a start index and length
+array[2, 3] #=> [3, 4, 5]
 
 # Or with a range
 array[1..3] #=> [2, 3, 4]


### PR DESCRIPTION
The #[i,l] method returns a subarray starting at index i and continuing for length l. [[source](http://ruby-doc.org/core-1.9.3/Array.html#method-i-5B-5D)]
