### PR TITLE
[scala/en] Source.fromPath no longer exists

### DIFF
--- a/scala.html.markdown
+++ b/scala.html.markdown
@@ -396,7 +396,7 @@ object Application {
 
 // To read a file line by line
 import scala.io.Source
-for(line <- Source.fromPath("myfile.txt").getLines())
+for(line <- Source.fromFile("myfile.txt").getLines())
   println(line)
 
 // To write a file use Java's PrintWriter


### PR DESCRIPTION
Latest _scala.io.Source_ can be viewed here: https://github.com/scala/scala/blob/master/src/library/scala/io/Source.scala  

Changed example to use Source.fromFile
