### PR TITLE
[csharp/en] Adds example of 'using' statement for resources handling

### DIFF
--- a/csharp.html.markdown
+++ b/csharp.html.markdown
@@ -435,14 +435,14 @@ on a new line! ""Wow!"", the masses cried";
             Func<int, int> square = (x) => x * x; // Last T item is the return value
             Console.WriteLine(square(3)); // 9
 
-            // DISPOSABLE RESSOURCES MANAGEMENT - let you handle unmanaged resources easily
+            // DISPOSABLE RESSOURCES MANAGEMENT - let you handle unmanaged resources easily.
             // Most of objects that access unmanaged resources (file handle, device contexts, etc.)
             // implement the IDisposable interface. The using statement takes care of 
             // cleaning those IDisposable objects for you.
             using (StreamWriter writer = new StreamWriter("log.txt"))
             {
                 writer.WriteLine("Nothing suspicious here");
-                // At the end of scope, ressources will be released.
+                // At the end of scope, resources will be released.
                 // Even if an exception is thrown.
             } 
 


### PR DESCRIPTION
Disposable resources handling with `using` is a recommanded practice in C#. 
Moreover, the example shows how to write into a file : a basic feature that readers could want to learn.
