### PR TITLE
clojure-cn: contributor and translator information

### DIFF
--- a/zh-cn/clojure-cn.html.markdown
+++ b/zh-cn/clojure-cn.html.markdown
@@ -2,6 +2,8 @@
 language: clojure
 filename: learnclojure-cn.clj
 contributors:
+    - ["Adam Bard", "http://adambard.com/"]
+translators:
     - ["Bill Zhang", "http://jingege.github.io/"]
 lang: zh-cn
 ---


### PR DESCRIPTION
The translator add his/her name to contributor instead of translator.
