### PR TITLE
[common-lisp/en] Fix invalid characters for Common Lisp symbols

### DIFF
--- a/common-lisp.html.markdown
+++ b/common-lisp.html.markdown
@@ -140,7 +140,7 @@ nil                  ; for false - and the empty list
 ;; 2. Variables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; You can create a global (dynamically scoped) using defparameter
-;; a variable name can use any character except: ()[]{}",'`;#|\
+;; a variable name can use any character except: ()",'`;#|\
 
 ;; Dynamically scoped variables should have earmuffs in their name!
 


### PR DESCRIPTION
The characters [ ] { and } are perfectly fine to use in variable names.

``` lisp
(defparameter b{l}a[b[l]]a "test") ; => B{L}A[B[L]]A
b{l}a[b[l]]a                       ; => "test"
```
