### PR TITLE
Remove references to hash and hashtag in favor of number symbol

### DIFF
--- a/coffeescript.html.markdown
+++ b/coffeescript.html.markdown
@@ -14,7 +14,7 @@ See also [the CoffeeScript website](http://coffeescript.org/), which has a compl
 ``` coffeescript
 # CoffeeScript is a hipster language.
 # It goes with the trends of many modern languages.
-# So comments are like Ruby and Python, they use hashes.
+# So comments are like Ruby and Python, they use number symbols.
 
 ###
 Block comments are like these, and they translate directly to '/ *'s and '* /'s

--- a/elixir.html.markdown
+++ b/elixir.html.markdown
@@ -11,7 +11,7 @@ and many more features.
 
 ```elixir
 
-# Single line comments start with a hashtag.
+# Single line comments start with a number symbol.
 
 # There's no multi-line comment,
 # but you can stack multiple comments.

--- a/julia.html.markdown
+++ b/julia.html.markdown
@@ -12,7 +12,7 @@ This is based on the current development version of Julia, as of October 18th, 2
 
 ```ruby
 
-# Single line comments start with a hash.
+# Single line comments start with a number symbol.
 #= Multiline comments can be written
    by putting '#=' before the text  and '=#' 
    after the text. They can also be nested.

--- a/livescript.html.markdown
+++ b/livescript.html.markdown
@@ -23,7 +23,7 @@ Feedback is always welcome, so feel free to reach me over at
 
 
 ```coffeescript
-# Just like its CoffeeScript cousin, LiveScript uses hash symbols for
+# Just like its CoffeeScript cousin, LiveScript uses number symbols for
 # single-line comments.
 
 /*

--- a/perl.html.markdown
+++ b/perl.html.markdown
@@ -12,7 +12,7 @@ Perl 5 is a highly capable, feature-rich programming language with over 25 years
 Perl 5 runs on over 100 platforms from portables to mainframes and is suitable for both rapid prototyping and large scale development projects.
 
 ```perl
-# Single line comments start with a hash.
+# Single line comments start with a number symbol.
 
 
 #### Perl variable types

--- a/python.html.markdown
+++ b/python.html.markdown
@@ -17,7 +17,7 @@ to Python 2.x. Look for another tour of Python 3 soon!
 
 ```python
 
-# Single line comments start with a hash.
+# Single line comments start with a number symbol.
 
 """ Multiline strings can be written
     using three "'s, and are often used

--- a/r.html.markdown
+++ b/r.html.markdown
@@ -10,7 +10,7 @@ R is a statistical computing language. It has lots of libraries for uploading an
 
 ```python
 
-# Comments start with hashtags.
+# Comments start with number symbols.
 
 # You can't make a multi-line comment per se,
 # but you can stack multiple comments like so.


### PR DESCRIPTION
Hashtags are Twitter, not programming. Also could be confusing between a `#` and the data structure.
