### PR TITLE
Fix syntax-errors in logical errors in Elisp guide.

### DIFF
--- a/elisp.html.markdown
+++ b/elisp.html.markdown
@@ -280,10 +280,10 @@ filename: learn-emacs-lisp.el
 ;; should stop searching at some point in the buffer, and whether it
 ;; should silently fail when nothing is found:
 
-;; (search-forward "Hello" nil t) does the trick:
+;; (search-forward "Hello" nil 't) does the trick:
 
 ;; The `nil' argument says: the search is not bound to a position.
-;; The `t' argument says: silently fail when nothing is found.
+;; The `'t' argument says: silently fail when nothing is found.
 
 ;; We use this sexp in the function below, which doesn't throw an error:
 
@@ -294,7 +294,7 @@ filename: learn-emacs-lisp.el
     (mapcar 'hello list-of-names)
     (goto-char (point-min))
     ;; Replace "Hello" by "Bonjour"
-    (while (search-forward "Hello" nil t)
+    (while (search-forward "Hello" nil 't)
       (replace-match "Bonjour"))
     (other-window 1))
 
@@ -305,7 +305,7 @@ filename: learn-emacs-lisp.el
 (defun boldify-names ()
     (switch-to-buffer-other-window "*test*")
     (goto-char (point-min))
-    (while (re-search-forward "Bonjour \\(.+\\)!" nil t)
+    (while (re-search-forward "Bonjour \\([^!]+\\)!" nil 't)
       (add-text-properties (match-beginning 1)
                            (match-end 1)
                            (list 'face 'bold)))
@@ -317,9 +317,9 @@ filename: learn-emacs-lisp.el
 
 ;; The regular expression is "Bonjour \\(.+\\)!" and it reads:
 ;; the string "Bonjour ", and
-;; a group of           | this is the \\( ... \\) construct
-;;   any character      | this is the .
-;;   possibly repeated  | this is the +
+;; a group of            | this is the \\( ... \\) construct
+;;   any character not ! | this is the [^!]
+;;   possibly repeated   | this is the +
 ;; and the "!" string.
 
 ;; Ready?  Test it!


### PR DESCRIPTION
Tested on latest emacs. Had to make some adjustments to make things behave as described.
