### PR TITLE
Golang - lack of information about named return values in functions

### DIFF
--- a/go.html.markdown
+++ b/go.html.markdown
@@ -118,9 +118,9 @@ can include line breaks.` // Same string type.
 
 // It is possible, unlike in many other languages for functions in go 
 // to have named return values.
-// Giving a name to type being returned allows us to easily return from 
-// multiple points in a function as well as to only use the return keyword, 
-// without anything further.
+// Assigning a name to the type being returned in the function declaration line
+// allows us to easily return from multiple points in a function as well as to 
+// only use the return keyword, without anything further.
 func learnNamedReturns(x, y int) (z int) {
     z = x * y
     return              // z is implicit here, because we named it earlier.


### PR DESCRIPTION
I felt that the bit about named return values in functions was a fairly significant omission. Hopefully I am not the only one who thinks so. At least from the standpoint of someone who might be new to go, knowing what it is helps when that newcomer is looking at someone else's code and encounters this style of function declaration.
