### PR TITLE
Remove duplication of function factory example

### DIFF
--- a/go.html.markdown
+++ b/go.html.markdown
@@ -214,13 +214,6 @@ func sentenceFactory(mystring string) func(before, after string) string {
     }
 }
 
-// Next two are equivalent, with second being more practical
-fmt.Println(learnFunctionFactory("summer")("A beautiful", "day!"))
-
-d := learnFunctionFactory("summer")
-fmt.Println(d("A beautiful", "day!"))
-fmt.Println(d("A lazy", "afternoon!"))
-
 func learnDefer() (ok bool) {
     // Deferred statements are executed just before the function returns.
     defer fmt.Println("deferred statements execute in reverse (LIFO) order.")


### PR DESCRIPTION
The removed example code appears almost identically (I think) in `func learnFunctionFactory ()` and I'm not sure the example is actually correct any more either?

Then again, I'm using this to learn Go so I may have overlooked something...

@soniakeys?
