### PR TITLE
[csharp/fr csharp/en] Fix 'filename' collision between csharp{,-fr}.html.markdown

### DIFF
--- a/fr-fr/csharp-fr.html.markdown
+++ b/fr-fr/csharp-fr.html.markdown
@@ -7,7 +7,7 @@ contributors:
     - ["Shaun McCarthy", "http://www.shaunmccarthy.com"]
 translators:
     - ["Olivier Hoarau", "https://github.com/Olwaro"]
-filename: LearnCSharp.cs
+filename: LearnCSharp-fr.cs
 lang: fr-fr
 ---
 


### PR DESCRIPTION
Both were set to LearnCSharp.cs, so the live site has been serving the French version for English.

(see set_rawcode: https://github.com/adambard/learnxinyminutes-site/blob/547a620dd8dc78f8518b0072e456ae2d384a0465/config.rb#L103)
