### PR TITLE
[go/en] add an example for range - fixes #351

### DIFF
--- a/go.html.markdown
+++ b/go.html.markdown
@@ -178,8 +178,8 @@ func learnFlowControl() {
 		continue // Unreached.
 	}
 
-	// you can use range to iterate over an array, a slice, a string, a map, or a channel.
-	// range returns one (channel) or two values (array, slice, string and map)
+	// You can use range to iterate over an array, a slice, a string, a map, or a channel.
+	// range returns one (channel) or two values (array, slice, string and map).
 	for key, value := range map[string]int{"one": 1, "two": 2, "three": 3} {
 		// for each pair in the map, print key and value
 		fmt.Printf("key=%s, value=%d\n", key, value)


### PR DESCRIPTION
Adding a simple range example, with some retails on possible values
