### PR TITLE
[javascript/*] typeof is an operator and not a function/method - fix usag...

### DIFF
--- a/de-de/javascript-de.html.markdown
+++ b/de-de/javascript-de.html.markdown
@@ -397,8 +397,8 @@ var myNumberObj = new Number(12);
 myNumber == myNumberObj; // = true
 
 // Genau genommen: Sie sind nicht exakt äquivalent.
-typeof(myNumber); // = 'number'
-typeof(myNumberObj); // = 'object'
+typeof myNumber; // = 'number'
+typeof myNumberObj; // = 'object'
 myNumber === myNumberObj; // = false
 if (0){
     // Dieser Teil wird nicht ausgeführt, weil 0 'falsy' ist.

--- a/es-es/javascript-es.html.markdown
+++ b/es-es/javascript-es.html.markdown
@@ -471,8 +471,8 @@ var miNumeroObjeto = new Number(12);
 miNumero == miNumeroObjeto; // = true
 
 // No son exactamente iguales.
-typeof(miNumero); // = 'number'
-typeof(miNumeroObjeto); // = 'object'
+typeof miNumero; // = 'number'
+typeof miNumeroObjeto; // = 'object'
 miNumero === miNumeroObjeyo; // = false
 if (0){
     // Este código no se ejecutara porque 0 es false.

--- a/fa-ir/javascript.html.markdown
+++ b/fa-ir/javascript.html.markdown
@@ -493,8 +493,8 @@ myNumber == myNumberObj; // = true
 
 <p dir='rtl'>به جز این که این سازنده ها دقیقا مانند سازنده های دیگر نیستند.</p>
 ```js
-typeof(myNumber); // = 'number'
-typeof(myNumberObj); // = 'object'
+typeof myNumber; // = 'number'
+typeof myNumberObj; // = 'object'
 myNumber === myNumberObj; // = false
 if (0){
     // This code won't execute, because 0 is falsy.

--- a/javascript.html.markdown
+++ b/javascript.html.markdown
@@ -460,8 +460,8 @@ var myNumberObj = new Number(12);
 myNumber == myNumberObj; // = true
 
 // Except, they aren't exactly equivalent.
-typeof(myNumber); // = 'number'
-typeof(myNumberObj); // = 'object'
+typeof myNumber; // = 'number'
+typeof myNumberObj; // = 'object'
 myNumber === myNumberObj; // = false
 if (0){
     // This code won't execute, because 0 is falsy.

--- a/ko-kr/javascript-kr.html.markdown
+++ b/ko-kr/javascript-kr.html.markdown
@@ -381,8 +381,8 @@ var myNumberObj = new Number(12)
 myNumber == myNumberObj // = true
 
 // 하지만 정확히 같지는 않습니다.
-typeof(myNumber) // = 'number'
-typeof(myNumberObj) // = 'object'
+typeof myNumber // = 'number'
+typeof myNumberObj // = 'object'
 myNumber === myNumberObj // = false
 if (0){
     // 0은 거짓이라서 이 코드는 실행되지 않습니다.

--- a/zh-cn/javascript-cn.html.markdown
+++ b/zh-cn/javascript-cn.html.markdown
@@ -363,8 +363,8 @@ var myNumberObj = new Number(12)
 myNumber == myNumberObj // = true
 
 // 但是它们并非严格等价
-typeof(myNumber) // = 'number'
-typeof(myNumberObj) // = 'object'
+typeof myNumber // = 'number'
+typeof myNumberObj // = 'object'
 myNumber === myNumberObj // = false
 if (0){
     // 这段代码不会执行，因为0代表假


### PR DESCRIPTION
The usage of `typeof` in all JS demos is misleading:

``` javascript
typeof(foo);
```

Although working just as expected this might lead to the conclusion that typeof is a method. Yet it is an operator: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof and should/can therefore be used **without** parens:

``` javascript
typeof foo;
```
