### PR TITLE
[swift/en]Fix class name from Rect to Square

### DIFF
--- a/swift.html.markdown
+++ b/swift.html.markdown
@@ -157,7 +157,7 @@ print(numbers) // [3, 6, 18]
 // structured object, you should use a `struct`
 
 // A simple class `Square` extends `Shape`
-class Rect: Shape {
+class Square: Shape {
   var sideLength: Int = 1
 
   // Custom getter and setter property


### PR DESCRIPTION
Hi there!
I am a regular user of the site and came across this issue just now.
The comments and code refer to a `Square` class, but the actual class was `Rect`.

Thank you very much for the great resource!
