### PR TITLE
[markdown/de] add german translation of markdown tutorial

### DIFF
--- a/de-de/markdown-de.html.markdown
+++ b/de-de/markdown-de.html.markdown
@@ -4,6 +4,7 @@ contributors:
     - ["Dan Turkel", "http://danturkel.com/"]
 translators :
     - ["Frederik Ring", "https://github.com/m90"]
+    - ["Philipp Fischbeck", "https://github.com/PFischbeck"]
 filename: markdown-de.md
 lang: de-de
 ---


### PR DESCRIPTION
This adds a german translation of `markdown`.

As always, a native-speaking proof-read before merging would be wonderful (and required), especially since I am **really** bad at commas (maybe @PFischbeck wants to give it another go - that would be really great).

Thanks!
