### PR TITLE
[ocaml/en] Syntax error fix and minor enhancements

### DIFF
--- a/ocaml.html.markdown
+++ b/ocaml.html.markdown
@@ -150,6 +150,8 @@ x + y ;;
    works for non-recursive definitions too. *)
 let a = 3 and b = 4 in a * b ;;
 
+(* Anonymous functions use the following syntax: *)
+let my_lambda = fun x -> x * x ;;
 
 (*** Operators ***)
 
@@ -206,6 +208,10 @@ let bad_list = [1, 2] ;; (* Becomes [(1, 2)] *)
 
 (* You can access individual list items with the List.nth function. *)
 List.nth my_list 1 ;;
+
+(* There are higher-order functions for lists such as map and filter. *)
+List.map (fun x -> x * 2) [1; 2; 3] ;;
+List.filter (fun x -> if x mod 2 = 0 then true else false) [1; 2; 3; 4] ;;
 
 (* You can add an item to the beginning of a list with the "::" constructor
    often referred to as "cons". *)


### PR DESCRIPTION
Fixed a syntax error in pattern matching section that would lead to unexpected results.
Removed horizontal scrolling. Clarified some stuff.
