### PR TITLE
[json/en] JSON should not use single quote delimited strings

### DIFF
--- a/json.html.markdown
+++ b/json.html.markdown
@@ -17,7 +17,7 @@ going to be 100% valid JSON. Luckily, it kind of speaks for itself.
 {
   "key": "value",
   
-  "keys": "must always be enclosed in quotes (either double or single)",
+  "keys": "must always be enclosed in double quotes",
   "numbers": 0,
   "strings": "Hellø, wørld. All unicode is allowed, along with \"escaping\".",
   "has bools?": true,


### PR DESCRIPTION
Although there may be parsers that allow the use of single quotes, it is definitely non-standard.

[JSON.org](http://json.org/) reads:

> A string is a sequence of zero or more Unicode characters, wrapped in double quotes, using backslash escapes.

Also, [JSONLint](http://jsonlint.com/) will complain about anything delimited by single quotes.

``` javascript
JSON.parse("{'key' : 'value'}");
```

will throw `SyntaxError: Unexpected token '`
