### PR TITLE
[go] Fix no new variables on left side of :=

### DIFF
--- a/go.html.markdown
+++ b/go.html.markdown
@@ -72,7 +72,7 @@ func learnMultiple(x, y int) (sum, prod int) {
 // Some built-in types and literals.
 func learnTypes() {
 	// Short declaration usually gives you what you want.
-	s := "Learn Go!" // string type.
+	str := "Learn Go!" // string type.
 
 	s2 := `A "raw" string literal
 can include line breaks.` // Same string type.
@@ -126,7 +126,7 @@ can include line breaks.` // Same string type.
 
 	// Unused variables are an error in Go.
 	// The underbar lets you "use" a variable but discard its value.
-	_, _, _, _, _, _, _, _, _ = s2, g, f, u, pi, n, a3, s4, bs
+	_, _, _, _, _, _, _, _, _, _ = str, s2, g, f, u, pi, n, a3, s4, bs
 	// Output of course counts as using a variable.
 	fmt.Println(s, c, a4, s3, d2, m)
 


### PR DESCRIPTION
Cannot short declaration twice without at least one new var.  Also changing type from string to slice.

$ go run learnxiny.go
// command-line-arguments
./learnxiny.go:83: no new variables on left side of :=
./learnxiny.go:83: cannot use []int literal (type []int) as type string in assignment
./learnxiny.go:84: first argument to append must be slice; have string
./learnxiny.go:90: first argument to append must be slice; have string
