### PR TITLE
Your Name: Matt

### DIFF
--- a/javascript.html.markdown
+++ b/javascript.html.markdown
@@ -77,13 +77,13 @@ false;
 !true; // = false
 !false; // = true
 
-// Equality is ==
-1 == 1; // = true
-2 == 1; // = false
+// Equality is ===
+1 === 1; // = true
+2 === 1; // = false
 
-// Inequality is !=
-1 != 1; // = false
-2 != 1; // = true
+// Inequality is !==
+1 !== 1; // = false
+2 !== 1; // = true
 
 // More comparisons
 1 < 10; // = true
@@ -97,11 +97,13 @@ false;
 // and are compared with < and >
 "a" < "b"; // = true
 
-// Type coercion is performed for comparisons...
+// Type coercion is performed for comparisons with double equals...
 "5" == 5; // = true
+null == undefined; // = true
 
 // ...unless you use ===
 "5" === 5; // = false
+null === undefined; // = false 
 
 // You can access characters in a string with charAt
 "This is a string".charAt(0);  // = 'T'


### PR DESCRIPTION
Subject Line: Addresses Comparisons in Javascript

What Happened:

I believe that starting out with the double equals instead of the triple equals for strict comparison checking is incorrect. Because double equals uses type coercion, it is more of a feature the needs to be understood. Beginners looking at the language should look upon the stricter method as the proper one because it is less likely to give a surprising result.

I also tried to address the behaviour by adding an example to the double equals comparison.

Hope that the community is interested in pulling in these changes, they stem from teaching beginners javaScript but I am by no means the authority.
