### PR TITLE
[tmux/en] Fix URL names

### DIFF
--- a/tmux.html.markdown
+++ b/tmux.html.markdown
@@ -239,6 +239,6 @@ set -g status-right "#[fg=green] | #[fg=white]#(tmux-mem-cpu-load)#[fg=green] | 
 
 <a href="http://tmux.sourceforge.net/">Tmux | Home</a><br>
 <a href="http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man1/tmux.1?query=tmux">Tmux Manual page</a><br>
-<a href="http://wiki.gentoo.org/wiki/Tmux">Archlinux Wiki</a><br>
-<a href="https://wiki.archlinux.org/index.php/Tmux">Gentoo Wiki</a><br>
+<a href="http://wiki.gentoo.org/wiki/Tmux">Gentoo Wiki</a><br>
+<a href="https://wiki.archlinux.org/index.php/Tmux">Archlinux Wiki</a><br>
 <a href="https://stackoverflow.com/questions/11558907/is-there-a-better-way-to-display-cpu-usage-in-tmux">Display CPU/MEM % in statusbar</a><br>


### PR DESCRIPTION
I was going through the tmux learnxinyminutes page when I noticed that the URLs to the Gentoo Wiki and ArchWiki were incorrectly named. I've fixed that in this.
