### PR TITLE
[matlab/en] Fix block comment syntax.

### DIFF
--- a/matlab.html.markdown
+++ b/matlab.html.markdown
@@ -15,10 +15,12 @@ If you have any feedback please feel free to reach me at
 ```matlab
 % Comments start with a percent sign.
 
-%{ Multi line comments look 
+%{
+Multi line comments look 
 something
 like
-this %}
+this
+%}
 
 % commands can span multiple lines, using '...':
  a = 1 + 2 + ...


### PR DESCRIPTION
The %{ and %} operators must appear alone on the lines that immediately
precede and follow the block of help text. Do not include any other text
on these lines.

Reference:
http://www.mathworks.com/help/matlab/matlab_prog/comments.html

---

In fact, I'm new to matlab, so let me know if I missed something.

I spotted this issue when I found the syntax highlight for block comments for matlab was not correct, so either the block comment syntax or the highlight went wrong. And a quick test in matlab tells...
