### PR TITLE
Got rid of misplaced apostrophe & updated note on Python 3 tutorial.

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -14,7 +14,7 @@ executable pseudocode.
 Feedback would be highly appreciated! You can reach me at [@louiedinh](http://twitter.com/louiedinh) or louiedinh [at] [google's email service]
 
 Note: This article applies to Python 2.7 specifically, but should be applicable
-to Python 2.x. Look for another tour of Python 3 soon!
+to Python 2.x. For Python 3.x, take a look at the Python 3 tutorial.
 
 ```python
 


### PR DESCRIPTION
-  Misplaced apostrophe: sorry, I couldn't help myself. It's kind of a pet peeve of mine.
-  Update on Python 3: now that the Python 3 tutorial exists, I figured it would make sense to highlight it.

JH
