### PR TITLE
Update c.html.markdown

### DIFF
--- a/c.html.markdown
+++ b/c.html.markdown
@@ -26,12 +26,14 @@ Multi-line comments look like this. They work in C89 as well.
 Multi-line comments don't nest /* Be careful */  // comment ends on this line...
 */ // ...not this one!
 
-  // Constants: #define <keyword>
+// Constants: #define <keyword>
 #define DAYS_IN_YEAR 365
 
-  // Enumeration constants are also ways to declare constants.
-  enum days {SUN = 1, MON, TUE, WED, THU, FRI, SAT};
+// Enumeration constants are also ways to declare constants.
+// All statements must end with a semicolon
+enum days {SUN = 1, MON, TUE, WED, THU, FRI, SAT};
 // MON gets 2 automatically, TUE gets 3, etc.
+
 
 // Import headers with #include
 #include <stdlib.h>
@@ -57,7 +59,6 @@ int main() {
   // print output using printf, for "print formatted"
   // %d is an integer, \n is a newline
   printf("%d\n", 0); // => Prints 0
-  // All statements must end with a semicolon
 
   ///////////////////////////////////////
   // Types


### PR DESCRIPTION
Changed indentation of comments at beginning.
Put "// All statements must end with a semicolon" at first occurrence of the semicolon (enum example).
