### PR TITLE
[scala] Fixed function return type

### DIFF
--- a/scala.html.markdown
+++ b/scala.html.markdown
@@ -199,7 +199,7 @@ weirdSum(2, 4)  // => 16
 
 // The return keyword exists in Scala, but it only returns from the inner-most
 // def that surrounds it. It has no effect on anonymous functions. For example:
-def foo(x: Int) = {
+def foo(x: Int): Int = {
   val anonFunc: Int => Int = { z =>
     if (z > 5)
       return z  // This line makes z the return value of foo!

--- a/scala.html.markdown
+++ b/scala.html.markdown
@@ -198,7 +198,9 @@ weirdSum(2, 4)  // => 16
 
 
 // The return keyword exists in Scala, but it only returns from the inner-most
-// def that surrounds it. It has no effect on anonymous functions. For example:
+// def that surrounds it. 
+// WARNING: Using return in Scala is error-prone and should be avoided. 
+// It has no effect on anonymous functions. For example:
 def foo(x: Int): Int = {
   val anonFunc: Int => Int = { z =>
     if (z > 5)


### PR DESCRIPTION
Scala compiler fails to infer the return type of the function when there's an explicit return statement used in the function