### PR TITLE
PYTHON3: Delete PYMOTW3 due to lack of content

### DIFF
--- a/python3.html.markdown
+++ b/python3.html.markdown
@@ -609,7 +609,6 @@ print(say(say_please=True))  # Can you buy me a beer? Please! I am poor :(
 
 * [The Official Docs](http://docs.python.org/3/)
 * [Hitchhiker's Guide to Python](http://docs.python-guide.org/en/latest/)
-* [Python Module of the Week](http://pymotw.com/3/)
 * [A Crash Course in Python for Scientists](http://nbviewer.ipython.org/5920182)
 
 ### Dead Tree


### PR DESCRIPTION
The Python module of the week for python 3 only has 1 module as of now. I deleted the link. 
