### PR TITLE
[julia/ja] Added missing `lang: ja-jp`

### DIFF
--- a/ja-jp/julia-jp.html.markdown
+++ b/ja-jp/julia-jp.html.markdown
@@ -5,6 +5,7 @@ contributors:
 translators:
     - ["Yuichi Motoyama", "https://github.com/yomichi"]
 filename: learnjulia-jp.jl
+lang: ja-jp
 ---
 
 Julia は科学技術計算向けに作られた、同図像性を持った(homoiconic) プログラミング言語です。


### PR DESCRIPTION
Sorry, I missed writing `lang: ja-jp` in #894, and made a new Julia language tree in the top page.