### PR TITLE
[lua/ru] a probable solution #957

### DIFF
--- a/ru-ru/lua-ru.html.markdown
+++ b/ru-ru/lua-ru.html.markdown
@@ -1,5 +1,5 @@
 ---
-language: lua
+language: Lua
 filename: learnlua-ru.lua
 contributors:
     - ["Tyler Neylon", "http://tylerneylon.com/"]


### PR DESCRIPTION
I'm not exactly familiar with LearnXinYMinutes-site parser. But if we replace the lowercase letter 'l' for a capital 'L', ru version of Lua is displayed on the main page. Please check this.