### PR TITLE
[hack/en] Fix link to other learnxinyminutes article

### DIFF
--- a/hack.html.markdown
+++ b/hack.html.markdown
@@ -11,7 +11,7 @@ useful features from statically typed languages.
 
 
 Only Hack-specific features are covered here. Details about PHP's syntax are
-available in the [PHP article](php.html.markdown).
+available in the [PHP article](http://learnxinyminutes.com/docs/php/) on this site.
 
 ```php
 <?hh
@@ -303,5 +303,5 @@ for more general information.
 
 Visit the [official HHVM website](http://hhvm.com/) for HHVM installation instructions.
 
-Visit [Hack's unsupported PHP features article](http://docs.hhvm.com/manual/en/hack.unsupported.php).]
+Visit [Hack's unsupported PHP features article](http://docs.hhvm.com/manual/en/hack.unsupported.php)
 for details on the backwards incompatibility between Hack and PHP.


### PR DESCRIPTION
I had assumed a relative link to another markdown file in this project would work, but it renders as:

    http://learnxinyminutes.com/docs/hack/php.html.markdown

instead of the desired:

    http://learnxinyminutes.com/docs/php/

I've replaced this relative link with an absolute link to where the target page is located on the published site. This commit also fixes a typo in markdown syntax at the end of the document.

If there's an alternative way you'd prefer for this internal link to work, let me know.