### PR TITLE
Perl6, minor change in comments

### DIFF
--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -283,7 +283,7 @@ for @array -> $variable {
 }
 
 # As we saw with given, for's default "current iteration" variable is `$_`.
-# That means you can use `when` in a `for` just like you were in a when.
+# That means you can use `when` in a `for` just like you were in a `given`.
 for @array {
   say "I've got $_";
   


### PR DESCRIPTION
It seems "when" should be replace by "given" at the end of the comment line.