### PR TITLE
Update haskell.html.markdown. Wrong explanation about '$' operator

### DIFF
--- a/haskell.html.markdown
+++ b/haskell.html.markdown
@@ -208,13 +208,13 @@ foo 5 -- 75
 -- to get rid of a lot of parentheses:
 
 -- before
-(even (fib 7)) -- true
+(even (fib 7)) -- false
 
 -- after
-even . fib $ 7 -- true
+even . fib $ 7 -- false
 
 -- equivalently
-even $ fib 7 -- true
+even $ fib 7 -- false
 
 ----------------------------------------------------
 -- 5. Type signatures

--- a/haskell.html.markdown
+++ b/haskell.html.markdown
@@ -205,9 +205,8 @@ foo 5 -- 75
 -- Haskell has another operator called `$`. This operator applies a function 
 -- to a given parameter. In contrast to standard function application, which 
 -- has highest possible priority of 10 and is left-associative, the `$` operator 
--- has priority of 0 and is right-associative. Such a low priority means that 
--- all other operators on both sides of `$` will be evaluated before applying 
--- the `$`.
+-- has priority of 0 and is right-associative. Such a low priority means that
+-- the expression on its right is applied as the parameter to the function on its left.
 
 -- before
 (even (fib 7)) -- false

--- a/haskell.html.markdown
+++ b/haskell.html.markdown
@@ -202,10 +202,12 @@ foo = (*5) . (+10)
 foo 5 -- 75
 
 -- fixing precedence
--- Haskell has another function called `$`. Anything appearing after it will 
--- take precedence over anything that comes before.
--- You can use `$` (often in combination with `.`)
--- to get rid of a lot of parentheses:
+-- Haskell has another operator called `$`. This operator applies a function 
+-- to a given parameter. In contrast to standard function application, which 
+-- has highest possible priority of 10 and is left-associative, the `$` operator 
+-- has priority of 0 and is right-associative. Such a low priority means that 
+-- all other operators on both sides of `$` will be evaluated before applying 
+-- the `$`.
 
 -- before
 (even (fib 7)) -- false


### PR DESCRIPTION
The right side of '$' is evaluated first, then the result is passed to the left side