### PR TITLE
Neither gcc nor clang accept void main.

### DIFF
--- a/c++.html.markdown
+++ b/c++.html.markdown
@@ -32,8 +32,7 @@ one of the most widely-used programming languages.
 // variable declarations, primitive types, and functions.
 
 // Just like in C, your program's entry point is a function called
-// main with an integer return type,
-// though void main() is also accepted by most compilers (gcc, clang, etc.)
+// main with an integer return type.
 // This value serves as the program's exit status.
 // See http://en.wikipedia.org/wiki/Exit_status for more information.
 int main(int argc, char** argv)


### PR DESCRIPTION
Neither gcc nor clang accept void main. Remove this bad information. Tested as follows:

    $ cat 045.cpp
    void main()
    {
    }
    $ g++ 045.cpp
    045.cpp:1:11: error: ‘::main’ must return ‘int’
     void main()
               ^
    $ clang++ 045.cpp
    045.cpp:1:1: error: 'main' must return 'int'
    void main()
    ^~~~
    int
    1 error generated.
    $ g++ --version
    g++ (Ubuntu 4.8.2-19ubuntu1) 4.8.2
    $ clang++ --version
    Ubuntu clang version 3.4.2-3ubuntu2~xedgers (tags/RELEASE_34/dot2-final) (based on LLVM 3.4.2)