### PR TITLE
[bash/en] Don't use ALL_CAPS variable names.

### DIFF
--- a/bash.html.markdown
+++ b/bash.html.markdown
@@ -32,40 +32,40 @@ echo Hello world!
 echo 'This is the first line'; echo 'This is the second line'
 
 # Declaring a variable looks like this:
-VARIABLE="Some string"
+Variable="Some string"
 
 # But not like this:
-VARIABLE = "Some string"
-# Bash will decide that VARIABLE is a command it must execute and give an error
+Variable = "Some string"
+# Bash will decide that Variable is a command it must execute and give an error
 # because it can't be found.
 
 # Or like this:
-VARIABLE= 'Some string'
+Variable= 'Some string'
 # Bash will decide that 'Some string' is a command it must execute and give an
-# error because it can't be found. (In this case the 'VARIABLE=' part is seen
+# error because it can't be found. (In this case the 'Variable=' part is seen
 # as a variable assignment valid only for the scope of the 'Some string'
 # command.)
 
 # Using the variable:
-echo $VARIABLE
-echo "$VARIABLE"
-echo '$VARIABLE'
+echo $Variable
+echo "$Variable"
+echo '$Variable'
 # When you use the variable itself — assign it, export it, or else — you write
 # its name without $. If you want to use variable's value, you should use $.
 # Note that ' (single quote) won't expand the variables!
 
 # String substitution in variables
-echo ${VARIABLE/Some/A}
+echo ${Variable/Some/A}
 # This will substitute the first occurance of "Some" with "A"
 
 # Substring from a variable
-LENGTH=7
-echo ${VARIABLE:0:LENGTH}
+Length=7
+echo ${Variable:0:Length}
 # This will return only the first 7 characters of the value
 
 # Default value for variable
-echo ${FOO:-"DefaultValueIfFOOIsMissingOrEmpty"}
-# This works for null (FOO=) and empty string (FOO=""); zero (FOO=0) returns 0.
+echo ${Foo:-"DefaultValueIfFooIsMissingOrEmpty"}
+# This works for null (Foo=) and empty string (Foo=""); zero (Foo=0) returns 0.
 # Note that it only returns default value and doesn't change variable value.
 
 # Builtin variables:
@@ -78,12 +78,12 @@ echo "Scripts arguments seperated in different variables: $1 $2..."
 
 # Reading a value from input:
 echo "What's your name?"
-read NAME # Note that we didn't need to declare a new variable
-echo Hello, $NAME!
+read Name # Note that we didn't need to declare a new variable
+echo Hello, $Name!
 
 # We have the usual if structure:
 # use 'man test' for more info about conditionals
-if [ $NAME -ne $USER ]
+if [ $Name -ne $USER ]
 then
     echo "Your name isn't your username"
 else
@@ -95,14 +95,14 @@ echo "Always executed" || echo "Only executed if first command fails"
 echo "Always executed" && echo "Only executed if first command does NOT fail"
 
 # To use && and || with if statements, you need multiple pairs of square brackets:
-if [ $NAME == "Steve" ] && [ $AGE -eq 15 ]
+if [ $Name == "Steve" ] && [ $Age -eq 15 ]
 then
-    echo "This will run if $NAME is Steve AND $AGE is 15."
+    echo "This will run if $Name is Steve AND $Age is 15."
 fi
 
-if [ $NAME == "Daniya" ] || [ $NAME == "Zach" ]
+if [ $Name == "Daniya" ] || [ $Name == "Zach" ]
 then
-    echo "This will run if $NAME is Daniya OR Zach."
+    echo "This will run if $Name is Daniya OR Zach."
 fi
 
 # Expressions are denoted with the following format:
@@ -171,7 +171,7 @@ echo "There are $(ls | wc -l) items here."
 echo "There are `ls | wc -l` items here."
 
 # Bash uses a case statement that works similarly to switch in Java and C++:
-case "$VARIABLE" in 
+case "$Variable" in
     #List patterns for the conditions you want to meet
     0) echo "There is a zero.";;
     1) echo "There is a one.";;
@@ -179,10 +179,10 @@ case "$VARIABLE" in
 esac
 
 # for loops iterate for as many arguments given:
-# The contents of $VARIABLE is printed three times.
-for VARIABLE in {1..3}
+# The contents of $Variable is printed three times.
+for Variable in {1..3}
 do
-    echo "$VARIABLE"
+    echo "$Variable"
 done
 
 # Or write it the "traditional for loop" way:
@@ -193,16 +193,16 @@ done
 
 # They can also be used to act on files..
 # This will run the command 'cat' on file1 and file2
-for VARIABLE in file1 file2
+for Variable in file1 file2
 do
-    cat "$VARIABLE"
+    cat "$Variable"
 done
 
 # ..or the output from a command
 # This will cat the output from ls.
-for OUTPUT in $(ls)
+for Output in $(ls)
 do
-    cat "$OUTPUT"
+    cat "$Output"
 done
 
 # while loop:
@@ -230,7 +230,7 @@ bar ()
 }
 
 # Calling your function
-foo "My name is" $NAME
+foo "My name is" $Name
 
 # There are a lot of useful commands you should learn:
 # prints last 10 lines of file.txt


### PR DESCRIPTION
ALL_CAPS variable names are traditionally "reserved" for use by the
shell/system.

(People often try to use PATH for things locally and then wonder why their
commands all stop working for example.)