### PR TITLE
[c++/en] Make code compileable.

### DIFF
--- a/c++.html.markdown
+++ b/c++.html.markdown
@@ -519,12 +519,13 @@ printMessage<10>();  // Prints "Learn C++ faster in only 10 minutes!"
 // (see http://en.cppreference.com/w/cpp/error/exception)
 // but any type can be thrown an as exception
 #include <exception>
+#include <stdexcept>
 
 // All exceptions thrown inside the _try_ block can be caught by subsequent
 // _catch_ handlers.
 try {
     // Do not allocate exceptions on the heap using _new_.
-    throw std::exception();
+    throw std::runtime_error("A problem occurred");
 }
 // Catch exceptions by const reference if they are objects
 catch (const std::exception& ex)

--- a/c++.html.markdown
+++ b/c++.html.markdown
@@ -523,7 +523,7 @@ printMessage<10>();  // Prints "Learn C++ faster in only 10 minutes!"
 // _catch_ handlers.
 try {
     // Do not allocate exceptions on the heap using _new_.
-    throw std::exception("A problem occurred");
+    throw std::exception();
 }
 // Catch exceptions by const reference if they are objects
 catch (const std::exception& ex)
@@ -614,7 +614,7 @@ void doSomethingWithAFile(const char* filename)
 {
     FILE* fh = fopen(filename, "r"); // Open the file in read mode
     if (fh == nullptr)
-        throw std::exception("Could not open the file.");
+        throw std::exception();
 
     try {
         doSomethingWithTheFile(fh);

--- a/c++.html.markdown
+++ b/c++.html.markdown
@@ -445,6 +445,7 @@ int main () {
 // define a class or function that takes a type parameter:
 template<class T>
 class Box {
+public:
     // In this class, T can be used as any other type.
     void insert(const T&) { ... }
 };

--- a/c++.html.markdown
+++ b/c++.html.markdown
@@ -616,7 +616,7 @@ void doSomethingWithAFile(const char* filename)
 {
     FILE* fh = fopen(filename, "r"); // Open the file in read mode
     if (fh == nullptr)
-        throw std::exception();
+        throw std::runtime_error("Could not open the file.");
 
     try {
         doSomethingWithTheFile(fh);


### PR DESCRIPTION
Made the template example class Box have a public member function so it works when that function is called later on. Also removed the string arguments from the std::exception constructors, because std::exception constructors only either take no argurments or another std::exception object.