### PR TITLE
Remove in-development from Rust's description

### DIFF
--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -5,7 +5,7 @@ contributors:
 filename: learnrust.rs
 ---
 
-Rust is an in-development programming language developed by Mozilla Research.
+Rust is a programming language developed by Mozilla Research.
 Rust combines low-level control over performance with high-level convenience and 
 safety guarantees. 
 


### PR DESCRIPTION
Now that Rust is stable at 1.0 saying "in-development" might not be appropriate any more.