### PR TITLE
Removed columns after "try" in julia tutorials.

### DIFF
--- a/es-es/julia-es.html.markdown
+++ b/es-es/julia-es.html.markdown
@@ -224,7 +224,7 @@ length(a) # => 8
 # Tuples son immutable.
 tup = (1, 2, 3) # => (1,2,3) # un (Int64,Int64,Int64) tuple.
 tup[1] # => 1
-try:
+try
     tup[1] = 3 # => ERROR: no method setindex!((Int64,Int64,Int64),Int64,Int64)
 catch e
     println(e)

--- a/ja-jp/julia-jp.html.markdown
+++ b/ja-jp/julia-jp.html.markdown
@@ -221,7 +221,7 @@ length(a) # => 8
 # 変更不可能 (immutable) な値の組として、タプルが使えます。
 tup = (1, 2, 3) # => (1,2,3) # an (Int64,Int64,Int64) tuple.
 tup[1] # => 1
-try:
+try
     tup[1] = 3 # => ERROR: no method setindex!((Int64,Int64,Int64),Int64,Int64)
 catch e
     println(e)

--- a/julia.html.markdown
+++ b/julia.html.markdown
@@ -213,7 +213,7 @@ length(a) # => 8
 # Tuples are immutable.
 tup = (1, 2, 3) # => (1,2,3) # an (Int64,Int64,Int64) tuple.
 tup[1] # => 1
-try:
+try
     tup[1] = 3 # => ERROR: no method setindex!((Int64,Int64,Int64),Int64,Int64)
 catch e
     println(e)

--- a/ru-ru/julia-ru.html.markdown
+++ b/ru-ru/julia-ru.html.markdown
@@ -214,7 +214,7 @@ length(a) # => 8
 # Кортеж — неизменяемая структура.
 tup = (1, 2, 3) # => (1,2,3) # кортеж (Int64,Int64,Int64).
 tup[1] # => 1
-try:
+try
     tup[1] = 3 # => ERROR: no method setindex!((Int64,Int64,Int64),Int64,Int64)
 catch e
     println(e)

--- a/zh-cn/julia-cn.html.markdown
+++ b/zh-cn/julia-cn.html.markdown
@@ -204,7 +204,7 @@ length(a) # => 8
 # Tuples 是 immutable 的
 tup = (1, 2, 3) # => (1,2,3) # an (Int64,Int64,Int64) tuple.
 tup[1] # => 1
-try:
+try
     tup[1] = 3 # => ERROR: no method setindex!((Int64,Int64,Int64),Int64,Int64)
 catch e
     println(e)


### PR DESCRIPTION
`try:` doesn't seem valid in julia. I replaced the occurrences with `try`.