### PR TITLE
Chapel: Sync, atomics, reductions, scans, zippered iterators

### DIFF
--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -765,6 +765,42 @@ proc countdown( seconds: int ){
   }
 }
 
+// Atomic variables, common to many languages, are ones whose operations
+// occur uninterupted. Multiple threads can both modify atomic variables
+// and can know that their values are safe.
+// Chapel atomic variables can be of type bool, int, uint, and real.
+var uranium: atomic int;
+uranium.write( 238 ); // atomically write a variable
+writeln( uranium.read() ); // atomically read a variable
+// operations are described as functions, you could define your own operators.
+uranium.sub( 3 ); // atomically subtract a variable
+writeln( uranium.read() );
+var replaceWith = 239;
+var was = uranium.exchange( replaceWith ); 
+writeln( "uranium was ", was, " but is now ", replaceWith );
+var isEqualTo = 235;
+if uranium.compareExchange( isEqualTo, replaceWith ) {
+  writeln( "uranium was equal to ", isEqualTo, 
+           " so replaced value with ", replaceWith );
+} else {
+  writeln( "uranium was not equal to ", isEqualTo, 
+           " value stays the same...  whatever it was" );
+}
+
+sync {
+  begin {
+    writeln( "Waiting to for uranium to be ", isEqualTo );
+    uranium.waitFor( isEqualTo );
+    writeln( "Uranium was set (by someone) to ", isEqualTo );
+  }
+
+  begin {
+    writeln( "Waiting to write uranium to ", isEqualTo );
+    countdown( 3 );
+    uranium.write( isEqualTo );
+  }
+}
+
 // sync vars have two states: empty and full.
 // If you read an empty variable or write a full variable, you are waited
 // until the variable is full or empty again
@@ -799,39 +835,6 @@ sync {
     writeln( "Writing in..." );
     countdown( 3 );
     someSingleVar$ = 5; // first and only write ever.
-  }
-}
-
-// atomic variables can be of type bool, int, uint, and real of any size.
-var uranium: atomic int;
-uranium.write( 238 ); // atomically write a variable
-writeln( uranium.read() ); // atomically read a variable
-// operations are described as functions, you could define your own operators.
-uranium.sub( 3 ); // atomically subtract a variable
-writeln( uranium.read() );
-var replaceWith = 239;
-var was = uranium.exchange( replaceWith ); 
-writeln( "uranium was ", was, " but is now ", replaceWith );
-var isEqualTo = 235;
-if uranium.compareExchange( isEqualTo, replaceWith ) {
-  writeln( "uranium was equal to ", isEqualTo, 
-           " so replaced value with ", replaceWith );
-} else {
-  writeln( "uranium was not equal to ", isEqualTo, 
-           " value stays the same...  whatever it was" );
-}
-
-sync {
-  begin {
-    writeln( "Waiting to for uranium to be ", isEqualTo );
-    uranium.waitFor( isEqualTo );
-    writeln( "Uranium was set (by someone) to ", isEqualTo );
-  }
-
-  begin {
-    writeln( "Waiting to write uranium to ", isEqualTo );
-    countdown( 3 );
-    uranium.write( isEqualTo );
   }
 }
 ```

--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -501,7 +501,7 @@ writeln( false ^ true  );
 writeln( true  ^ false );
 writeln( false ^ false );
 
-// Define a * operator on any two types that returns a tupe of those types
+// Define a * operator on any two types that returns a tuple of those types
 proc *( left : ?ltype, right : ?rtype): ( ltype, rtype ){
   return (left, right );
 }

--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -533,11 +533,13 @@ iter oddsThenEvens( N: int ): int {
 for i in oddsThenEvens( 10 ) do write( i, ", " );
 writeln( );
 
-// The 'zippered' iterator is an iterator that takes two or more iterators that 
-// have the same number of iterations and zips them together into one stream
-                        // Ranges have implicit iterators
-for (odd, even) in zip( 1..#10 by 2, 2..#10 by 2 ) do 
-  writeln( (odd, even) );
+// We can zipper together two or more iterators (who have the same number 
+// of iterations)  using zip() to create a single zipped iterator, where each 
+// iteration of the zipped iterator yields a tuple of one value yielded 
+// from each iterator.
+                                 // Ranges have implicit iterators
+for (positive, negative) in zip( 1..5, -5..-1) do 
+  writeln( (positive, negative) );
 
 // Classes are similar to those in C++ and Java.
 // They currently lack privatization

--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -837,6 +837,25 @@ sync {
     someSingleVar$ = 5; // first and only write ever.
   }
 }
+
+// we can define the operations + * & | ^ && || min max minloc maxloc
+// over an entire array using scans and reductions
+// Reductions apply the operation over the entire array and
+// result in a single value
+var listOfValues: [1..10] int = [456,354,15,57,36,45,15,8,678,2];
+var sumOfValues = + reduce listOfValues;
+var maxValue = max reduce listOfValues; // give just max value
+// gives max value and index of the max value
+var (theMaxValue, idxOfMax) = maxloc reduce zip(listOfValues, listOfValues.domain);
+writeln( (sumOfValues, maxValue, idxOfMax, listOfValues[ idxOfMax ] ) );
+
+// Scans apply the operation incrementally and return an array of the
+// value of the operation at that index as it progressed through the 
+// array from array.domain.low to array.domain.high
+var runningSumOfValues = + scan listOfValues;
+var maxScan = max scan listOfValues;
+writeln( runningSumOfValues );
+writeln( maxScan );
 ```
 
 Who is this tutorial for?

--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -35,7 +35,7 @@ var mySecondVar = myVar;
 // var anError; // this would be a compile time error.
 
 // We can (and should) explicitly type things
-var myThirdVar: real; // define mySecondVar as a real
+var myThirdVar: real;
 var myFourthVar: real = -1.234;
 myThirdVar = myFourthVar;
 

--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -32,7 +32,7 @@ stderr.writeln( "This goes to standard error" );
 var myVar = 10; // 10 is an int, so myVar is implicitly an int
 myVar = -10;
 var mySecondVar = myVar;
-// var anError; // this would be a compile time error.
+// var anError; // this would be a compile-time error.
 
 // We can (and should) explicitly type things
 var myThirdVar: real;
@@ -57,11 +57,11 @@ var my64Real: real(64) = 1.516; // 64 bit (8 bytes) sized real
 var intFromReal = myReal : int;
 var intFromReal2: int = myReal : int;
 
-// consts are constants, they cannot be changed after set in runtime
+// consts are constants, they cannot be changed after set in runtime.
 const almostPi: real = 22.0/7.0;
 
-// params are constants whose value must be known statically at compile time
-// Like consts, they cannot be changed during runtime
+// params are constants whose value must be known statically at compile-time
+// Their value cannot be changed.
 param compileTimeConst: int = 16;
 
 // The config modifier allows values to be set at the command line
@@ -71,10 +71,10 @@ config var varCmdLineArg: int = -123;
 config const constCmdLineArg: int = 777;
 // Set with --VarName=Value or --VarName Value at run time
 
-// config params can be set at compile time
+// config params can be set/changed at compile-time
 config param paramCmdLineArg: bool = false;
+// Set config with --set paramCmdLineArg=value at compile-time
 writeln( varCmdLineArg, ", ", constCmdLineArg, ", ", paramCmdLineArg );
-// Set config with --set paramCmdLineArg=value at compile time
 
 // refs operate much like a reference in C++
 var actual = 10;
@@ -465,7 +465,7 @@ genericProc( 1.0+2.0i, 3.0+4.0i );
 
 // We can also enforce a form of polymorphism with the 'where' clause
 // This allows the compiler to decide which function to use.
-// Note: that means that all information needs to be known at compile time. 
+// Note: that means that all information needs to be known at compile-time. 
 // The param modifier on the arg is used to enforce this constraint.
 proc whereProc( param N : int ): void
  where ( N > 0 ) {
@@ -896,6 +896,7 @@ Builds like other compilers:
 
 ```chpl myFile.chpl -o myExe```
 
-A notable argument:
+Notable arguments:
 
  * ``--fast``: enables a number of optimizations and disables array bounds checks. Should only enable when application is stable.
+ * ```--set <Symbol Name>=<Value>```: set config param <Symbol Name> to <Value> at compile-time

--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -65,7 +65,7 @@ const almostPi: real = 22.0/7.0;
 param compileTimeConst: int = 16;
 
 // The config modifier allows values to be set at the command line
-// and is much easier that the usual getOpts debacle 
+// and is much easier than the usual getOpts debacle 
 // config vars and consts can be changed through the command line at run time
 config var varCmdLineArg: int = -123; 
 config const constCmdLineArg: int = 777;


### PR DESCRIPTION
Added sync, single and atomic variables.
Added reductions and scans.
Because max/minloc require the values and indices to be in a zippered iterator, I included a demonstration of zippered iterators along with the previous iterator example. 

Further, made a number of spelling, grammar, wording, punctuation changes, and corrected/clarified some erroneous/misleading comments (mainly things about consts and params)

Included the `--set` compiler option in the Notable arguments 'section'.