### PR TITLE
[Chapel] Modules, main(), range/domain/array slicing and array assignment, loop expressions, zipped iterators

### DIFF
--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -683,7 +683,7 @@ module OurModule {
   // We can use modules inside of other modules.
   use Time;
   
-  // We'll use this a procedure in the parallelism section.
+  // We'll use this procedure in the parallelism section.
   proc countdown( seconds: int ){
     for i in 1..seconds by -1 {
       writeln( i );
@@ -691,7 +691,7 @@ module OurModule {
     }
   } 
   
-  // Submodule of Ourmodule 
+  // Submodules of OurModule 
   // It is possible to create arbitrarily deep module nests.
   module ChildModule {
     proc foo(){
@@ -726,7 +726,7 @@ foo();   // Less explicit call on ChildModule.foo()
 proc main(){
 
   // Parallelism
-  // In other languages, parallelism is typically this is done with 
+  // In other languages, parallelism is typically done with 
   // complicated libraries and strange class structure hierarchies.
   // Chapel has it baked right into the language.
 
@@ -820,13 +820,6 @@ proc main(){
 
   // or iterate over indicies
   [ idx in myBigArray.domain ] myBigArray[idx] = -myBigArray[idx]; 
-
-  proc countdown( seconds: int ){
-    for i in 1..seconds by -1 {
-      writeln( i );
-      sleep( 1 );
-    }
-  }
 
   // Atomic variables, common to many languages, are ones whose operations
   // occur uninterupted. Multiple threads can both modify atomic variables

--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -673,15 +673,14 @@ var copyNewTypeList = new GenericClass( realList, int );
 for value in copyNewTypeList do write( value, ", " );
 writeln( );
 
-
 // Modules are Chapel's way of managing name spaces.
 // The files containing these modules do not need to be named after the modules
-// (as is with Java), but files implicitly name modules.
+// (as in Java), but files implicitly name modules.
 // In this case, this file implicitly names the 'learnchapel' module
 
 module OurModule {
   // We can use modules inside of other modules.
-  use Time;
+  use Time; // Time is one of the standard modules.
   
   // We'll use this procedure in the parallelism section.
   proc countdown( seconds: int ){
@@ -947,7 +946,7 @@ proc main(){
   var maxScan = max scan listOfValues;
   writeln( runningSumOfValues );
   writeln( maxScan );
-}
+} // end main()
 ```
 
 Who is this tutorial for?
@@ -1010,4 +1009,4 @@ Notable arguments:
  * `--fast`: enables a number of optimizations and disables array bounds checks. Should only enable when application is stable.
  * `--set <Symbol Name>=<Value>`: set config param `<Symbol Name>` to `<Value>` at compile-time.
  * `--main-module <Module Name>`: use the main() procedure found in the module `<Module Name>` as the executable's main.
- * `--module-dir <Directory>`: includes `<Directory` in the module search path.
+ * `--module-dir <Directory>`: includes `<Directory>` in the module search path.

--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -968,9 +968,8 @@ Occasionally check back here and on the [Chapel site](http://chapel.cray.com) to
 
 ### What this tutorial is lacking:
 
- * Modules and standard modules
+ * Exposition of the standard modules
  * Multiple Locales (distributed memory system)
- * ```proc main(){ ... }```
  * Records
  * Whole/sliced array assignment
  * Range and domain slicing
@@ -994,26 +993,28 @@ Chapel can be built and installed on your average 'nix machine (and cygwin).
 [Download the latest release version](https://github.com/chapel-lang/chapel/releases/)
 and its as easy as 
 
- 1. ```tar -xvf chapel-1.11.0.tar.gz```
- 2. ```cd chapel-1.11.0```
- 3. ```make```
- 4. ```source util/setchplenv.bash # or .sh or .csh or .fish```
+ 1. `tar -xvf chapel-1.11.0.tar.gz`
+ 2. `cd chapel-1.11.0`
+ 3. `make`
+ 4. `source util/setchplenv.bash # or .sh or .csh or .fish`
 
 You will need to `source util/setchplenv.EXT` from within the Chapel directory (`$CHPL_HOME`) every time your terminal starts so its suggested that you drop that command in a script that will get executed on startup (like .bashrc).
 
 Chapel is easily installed with Brew for OS X
 
- 1. ```brew update```
- 2. ```brew install chapel```
+ 1. `brew update`
+ 2. `brew install chapel`
 
 Compiling Code
 --------------
 
 Builds like other compilers:
 
-```chpl myFile.chpl -o myExe```
+`chpl myFile.chpl -o myExe`
 
 Notable arguments:
 
- * ``--fast``: enables a number of optimizations and disables array bounds checks. Should only enable when application is stable.
- * ```--set <Symbol Name>=<Value>```: set config param <Symbol Name> to <Value> at compile-time
+ * `--fast`: enables a number of optimizations and disables array bounds checks. Should only enable when application is stable.
+ * `--set <Symbol Name>=<Value>`: set config param `<Symbol Name>` to `<Value>` at compile-time.
+ * `--main-module <Module Name>`: use the main() procedure found in the module `<Module Name>` as the executable's main.
+ * `--module-dir <Directory>`: includes `<Directory` in the module search path.


### PR DESCRIPTION
This is quite the doozie.
Added modules and main() proc.
Added range/domain/array slicing.
Added array assignment (which is part of array slicing) and loop expressions, which necessitated a deeper dive into zipped iterators to explain why some expressions would work, and why some wouldn't.
Added a fix because `<THESE THINGS>` were missing from the Notable arguments section.
A small change was made in one or two places to keep within the 80 column specifications.