### PR TITLE
In perl6, 0 is not falsey anymore

### DIFF
--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -213,7 +213,7 @@ say $x; #=> 52
 # - `if`
 # Before talking about `if`, we need to know which values are "Truthy"
 #  (represent True), and which are "Falsey" (or "Falsy") -- represent False.
-# Only these values are Falsey: (), 0, "", Nil, A type (like `Str` or `Int`),
+# Only these values are Falsey: (), "", Nil, A type (like `Str` or `Int`),
 #  and of course False itself.
 # Every other value is Truthy.
 if True {


### PR DESCRIPTION
0 is not falsey for a long time. For example, see this blog post: https://p6weekly.wordpress.com/2015/04/13/2015-15-we-figured-out-the-truth-about-0/


> Something that may have surprised a lot of people (myself included) was that Perl 6 claims that the truth value of “0” ought to be False. That is no longer the case, and so the rule for the truth value of strings is now just “does it have any characters in it?”. I think that’s more sensible.