### PR TITLE
Tcl. Fix mid-page rendering error

### DIFF
--- a/tcl.html.markdown
+++ b/tcl.html.markdown
@@ -149,6 +149,9 @@ set greeting "Hello, [set {first name}]"
 
 # To promote the words within a word to individual words of the current
 # command, use the expansion operator, "{*}".
+```
+
+```tcl
 set {*}{name Neo}
 
 # is equivalent to


### PR DESCRIPTION
Github's syntax-highlighting has an error in the Tcl syntax-parser causing the rendering of the page to fail about one third in.

See the following screenshot:

![error-example](https://cloud.githubusercontent.com/assets/411338/9604497/5c1aa90e-50b8-11e5-8209-2adb65f0f1aa.png)

This commit bypasses this rendering-error by resetting the syntax highlighting after the error has occurred.