### PR TITLE
[python/en] Add note about Python Module Order of Import

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -569,6 +569,12 @@ math.sqrt == m.sqrt == sqrt  # => True
 import math
 dir(math)
 
+# If you have a Python script named math.py in the same
+# folder as your current script, the file math.py will 
+# be loaded instead of the built-in Python module. 
+# This happens because the local folder has priority
+# over Python's built-in libraries. 
+
 
 ####################################################
 ## 7. Advanced

--- a/python3.html.markdown
+++ b/python3.html.markdown
@@ -591,6 +591,11 @@ math.sqrt(16) == m.sqrt(16)   # => True
 import math
 dir(math)
 
+# If you have a Python script named math.py in the same
+# folder as your current script, the file math.py will
+# be loaded instead of the built-in Python module.
+# This happens because the local folder has priority
+# over Python's built-in libraries.
 
 ####################################################
 ## 7. Advanced


### PR DESCRIPTION
Just a small note on importing modules for python that can save some debugging time should you have a file with a generic name in a multi-file project.