### PR TITLE
markdown example: fixed missing ! to create an actual comment

### DIFF
--- a/markdown.html.markdown
+++ b/markdown.html.markdown
@@ -160,7 +160,7 @@ def foobar
 end
 \`\`\` <!-- here too, no backslashes, just ``` -->
 
-<-- The above text doesn't require indenting, plus Github will use syntax
+<!-- The above text doesn't require indenting, plus Github will use syntax
 highlighting of the language you specify after the ``` -->
 
 <!-- Horizontal rule (<hr />) -->


### PR DESCRIPTION
Line 163 was missing a character to denote the HTML comment (shown as `<---` instead of `<!---`), which was causing everything subsequently to be rendered as code block, as the triple back tick wasn't being escaped as part of a comment