### PR TITLE
[csharp/de,fr,tr,cn] Put demonstrative condition into ternary expression

### DIFF
--- a/de-de/csharp-de.html.markdown
+++ b/de-de/csharp-de.html.markdown
@@ -248,7 +248,8 @@ zur nächsten Zeile, ""Wahnsinn!"", die Massen waren kaum zu bändigen";
             // Ternärer Operator
             // Anstatt eines einfachen if/else lässt sich auch folgendes schreiben:
             // <condition> ? <true> : <false>
-            string isTrue = true ? "Ja" : "Nein";
+            int zumVergleich = 17;
+            string isTrue = zumVergleich == 17 ? "Ja" : "Nein";
 
             // while-Schleife
             int fooWhile = 0;

--- a/fr-fr/csharp-fr.html.markdown
+++ b/fr-fr/csharp-fr.html.markdown
@@ -239,7 +239,8 @@ sur une nouvelle ligne! ""Wow!"", quel style";
             // Opérateur ternaire
             // Un simple if/else peut s'écrire :
             // <condition> ? <valeur si true> : <valeur si false>
-            string isTrue = (true) ? "True" : "False";
+            int toCompare = 17;
+            string isTrue = toCompare == 17 ? "True" : "False";
 
             // Boucle while
             int fooWhile = 0;

--- a/tr-tr/csharp-tr.html.markdown
+++ b/tr-tr/csharp-tr.html.markdown
@@ -234,7 +234,8 @@ on a new line! ""Wow!"", the masses cried";
             // Üçlü operatörler
             // Basit bir if/else ifadesi şöyle yazılabilir
             // <koşul> ? <true> : <false>
-            string isTrue = (true) ? "True" : "False";
+            int toCompare = 17;
+            string isTrue = toCompare == 17 ? "True" : "False";
 
             // While döngüsü
             int fooWhile = 0;

--- a/zh-cn/csharp-cn.html.markdown
+++ b/zh-cn/csharp-cn.html.markdown
@@ -232,7 +232,8 @@ on a new line! ""Wow!"", the masses cried";
             // 三元表达式
             // 简单的 if/else 语句可以写成：
             // <条件> ? <真> : <假>
-            string isTrue = (true) ? "True" : "False";
+            int toCompare = 17;
+            string isTrue = toCompare == 17 ? "True" : "False";
 
             // While 循环
             int fooWhile = 0;


### PR DESCRIPTION
It should be made clear that the part before the ternary operator is
indeed a condition, most often created as some comparison expression.

the same change for the English version has just been merged (see closed issue  #1333)