### PR TITLE
[swift/en] Updated link to correct page

### DIFF
--- a/swift.html.markdown
+++ b/swift.html.markdown
@@ -12,7 +12,7 @@ Swift is a programming language for iOS and OS X development created by Apple. D
 
 The official [Swift Programming Language](https://itunes.apple.com/us/book/swift-programming-language/id881256329) book from Apple is now available via iBooks.
 
-See also Apple's [getting started guide](https://developer.apple.com/library/prerelease/ios/referencelibrary/GettingStarted/RoadMapiOS/index.html), which has a complete tutorial on Swift.
+See also Apple's [getting started guide](https://developer.apple.com/library/prerelease/ios/referencelibrary/GettingStarted/DevelopiOSAppsSwift/), which has a complete tutorial on Swift.
 
 ```swift
 // import a module


### PR DESCRIPTION
Original link directs to page that can't be found. Changed to represent new location of the Apple Developer tutorial on swift.