### PR TITLE
[perl6] fix the output of ff example

### DIFF
--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -1429,7 +1429,7 @@ for <well met young hero we shall meet later> {
 # A flip-flop can change state as many times as needed:
 for <test start print it stop not printing start print again stop not anymore> {
   .say if $_ eq 'start' ^ff^ $_ eq 'stop'; # exclude both "start" and "stop",
-                                           #=> "print this printing again"
+                                           #=> "print it print again"
 }
 
 # you might also use a Whatever Star,


### PR DESCRIPTION
the output for this example of the ff operator is wrong. This PR fixes it