### PR TITLE
[objective-c/en] Enable syntax highlighting

### DIFF
--- a/coffeescript.html.markdown
+++ b/coffeescript.html.markdown
@@ -7,7 +7,7 @@ filename: coffeescript.coffee
 ---
 
 CoffeeScript is a little language that compiles one-to-one into the equivalent JavaScript, and there is no interpretation at runtime.
-As one of the succeeders of JavaScript, CoffeeScript tries its best to output readable, pretty-printed and smooth-running JavaScript codes working well in every JavaScript runtime.
+As one of the successors to JavaScript, CoffeeScript tries its best to output readable, pretty-printed and smooth-running JavaScript code, which works well in every JavaScript runtime.
 
 See also [the CoffeeScript website](http://coffeescript.org/), which has a complete tutorial on CoffeeScript.
 

--- a/coffeescript.html.markdown
+++ b/coffeescript.html.markdown
@@ -7,7 +7,7 @@ filename: coffeescript.coffee
 ---
 
 CoffeeScript is a little language that compiles one-to-one into the equivalent JavaScript, and there is no interpretation at runtime.
-As one of the successors to JavaScript, CoffeeScript tries its best to output readable, pretty-printed and smooth-running JavaScript code, which works well in every JavaScript runtime.
+As one of the succeeders of JavaScript, CoffeeScript tries its best to output readable, pretty-printed and smooth-running JavaScript codes working well in every JavaScript runtime.
 
 See also [the CoffeeScript website](http://coffeescript.org/), which has a complete tutorial on CoffeeScript.
 

--- a/objective-c.html.markdown
+++ b/objective-c.html.markdown
@@ -13,7 +13,7 @@ filename: LearnObjectiveC.m
 Objective-C is the main programming language used by Apple for the OS X and iOS operating systems and their respective frameworks, Cocoa and Cocoa Touch.
 It is a general-purpose, object-oriented programming language that adds Smalltalk-style messaging to the C programming language.
 
-```objective_c
+```objective-c
 // Single-line comments start with //
 
 /*


### PR DESCRIPTION
The identifier used for syntax highlighting was incorrect