### PR TITLE
Fix compile errors of the English and French Scala tutorials

### DIFF
--- a/fr-fr/scala.html.markdown
+++ b/fr-fr/scala.html.markdown
@@ -208,6 +208,7 @@ sSquared.reduce (_+_)
 // La fonction filter prend un prédicat (une fonction de type A -> Booléen) et
 // sélectionne tous les éléments qui satisfont ce prédicat
 List(1, 2, 3) filter (_ > 2) // List(3)
+case class Person(name: String, age: Int)
 List(
   Person(name = "Dom", age = 23),
   Person(name = "Bob", age = 30)
@@ -217,6 +218,7 @@ List(
 
 // Scala a une méthode foreach définie pour certaines collections
 // qui prend en argument une fonction renvoyant Unit (une méthode void)
+val aListOfNumbers = List(1, 2, 3, 4, 10, 20, 100)
 aListOfNumbers foreach (x => println(x))
 aListOfNumbers foreach println
 
@@ -271,11 +273,12 @@ i    // Montre la valeur de i. Notez que while est une boucle au sens classique.
      // mais utiliser des combinateurs et des compréhensions comme ci-dessus est plus
      // facile pour comprendre et pour faire la parallélisation
 
+i = 0
 // La boucle do while
 do {
   println("x is still less then 10");
-  x += 1
-} while (x < 10)
+  i += 1
+} while (i < 10)
 
 
 // La récursivité est un moyen idiomatique de faire une chose répétitive en Scala.
@@ -370,7 +373,7 @@ val email(user, domain) = "henry@zkpr.com"
 
 "Les chaînes de caractères Scala sont entourées de doubles guillements"
 'a' // Un caractère de Scala
-'Les simples guillemets n'existent pas en Scala // Erreur
+// 'Les simples guillemets n'existent pas en Scala' // Erreur
 "Les chaînes de caractères possèdent les méthodes usuelles de Java".length
 "Il y a aussi quelques méthodes extra de Scala.".reverse
 

--- a/scala.html.markdown
+++ b/scala.html.markdown
@@ -6,7 +6,6 @@ contributors:
     - ["Dominic Bou-Samra", "http://dbousamra.github.com"]
     - ["Geoff Liu", "http://geoffliu.me"]
     - ["Ha-Duong Nguyen", "http://reference-error.org"]
-filename: learn.scala
 ---
 
 Scala - the scalable language
@@ -244,10 +243,11 @@ i    // Show the value of i. Note that while is a loop in the classical sense -
      // comprehensions above is easier to understand and parallelize
 
 // A do while loop
+i = 0
 do {
-  println("x is still less than 10")
-  x += 1
-} while (x < 10)
+  println("i is still less than 10")
+  i += 1
+} while (i < 10)
 
 // Tail recursion is an idiomatic way of doing recurring things in Scala.
 // Recursive functions need an explicit return type, the compiler can't infer it.
@@ -566,8 +566,8 @@ sendGreetings("Jane")  // => "Hello Jane, 100 blessings to you and yours!"
 // Implicit function parameters enable us to simulate type classes in other
 // functional languages. It is so often used that it gets its own shorthand. The
 // following two lines mean the same thing:
-def foo[T](implicit c: C[T]) = ...
-def foo[T : C] = ...
+// def foo[T](implicit c: C[T]) = ...
+// def foo[T : C] = ...
 
 
 // Another situation in which the compiler looks for an implicit is if you have


### PR DESCRIPTION
The Scala tutorials had some small bugs, namely:

* Attempting to use an immutable variable `x` to control a loop;
* Uncommented code that would not compile, as it's not valid scala;
* Undefined lists and case classes;
* Two filenames;

This errors are also fixed on the pt-pt version (PR #1316).