### PR TITLE
Added detail on C# single inheritance

### DIFF
--- a/csharp.html.markdown
+++ b/csharp.html.markdown
@@ -837,7 +837,8 @@ on a new line! ""Wow!"", the masses cried";
         bool Broken { get; } // interfaces can contain properties as well as methods & events
     }
 
-    // Class can inherit only one other class, but can implement any amount of interfaces
+    // Class can inherit only one other class, but can implement any amount of interfaces, however
+    // the base class name must be the first in the list and all interfaces follow
     class MountainBike : Bicycle, IJumpable, IBreakable
     {
         int damage = 0;


### PR DESCRIPTION
Clarified that the base class name must be the first thing listed