### PR TITLE
[haml/fr] Add lang to header

### DIFF
--- a/fr-fr/haml-fr.html.markdown
+++ b/fr-fr/haml-fr.html.markdown
@@ -4,6 +4,7 @@ filename: learnhaml.haml
 contributors:
   - ["Simon Neveu", "https://github.com/sneveu"]
   - ["Thibault", "https://github.com/iTech-"]
+lang: fr-fr
 ---
 
 Haml est un langage de balisage utilisé majoritairement avec Ruby, qui décrit de manière simple et propre le HTML de n'importe quelle page web sans l'utilisation des traditionnelles lignes de code. Le langage est une alternative très populaire au langage de templates Rails (.erb) et permet d'intégrer du code en Ruby dans votre balisage.


### PR DESCRIPTION
Header configuration was missing `lang` field.