### PR TITLE
[json/en] Fixed incorrect information about commas in JSON doc

### DIFF
--- a/json.html.markdown
+++ b/json.html.markdown
@@ -58,7 +58,7 @@ Drawbacks of JSON include lack of type definition and some sort of DTD.
 
   "alternative style": {
     "comment": "check this out!"
-  , "comma position": "doesn't matter - as long as it's before the value, then it's valid"
+  , "comma position": "doesn't matter - as long as it's before the next key, then it's valid"
   , "another comment": "how nice"
   },
 


### PR DESCRIPTION
Original version indicated that commas are placed before _values_ in JSON, which is incorrect.