### PR TITLE
Added information about out parameters in C#

### DIFF
--- a/csharp.html.markdown
+++ b/csharp.html.markdown
@@ -395,8 +395,8 @@ on a new line! ""Wow!"", the masses cried";
             ref int maxCount, // Pass by reference
             out int count)
         {
-		//the argument passed in as 'count' will hold the value of 15 outside of this function
-		count = 15; // out param must be assigned before control leaves the method
+			//the argument passed in as 'count' will hold the value of 15 outside of this function
+			count = 15; // out param must be assigned before control leaves the method
         }
 
         // GENERICS

--- a/csharp.html.markdown
+++ b/csharp.html.markdown
@@ -7,6 +7,7 @@ contributors:
     - ["Shaun McCarthy", "http://www.shaunmccarthy.com"]
     - ["Wouter Van Schandevijl", "http://github.com/laoujin"]
     - ["Jo Pearce", "http://github.com/jdpearce"]
+    - ["Chris Zimmerman", "https://github.com/chriszimmerman"]
 filename: LearnCSharp.cs
 ---
 
@@ -394,6 +395,7 @@ on a new line! ""Wow!"", the masses cried";
             ref int maxCount, // Pass by reference
             out int count)
         {
+			//the argument passed in as 'count' will hold the value of 15 outside of this function
             count = 15; // out param must be assigned before control leaves the method
         }
 

--- a/csharp.html.markdown
+++ b/csharp.html.markdown
@@ -395,8 +395,8 @@ on a new line! ""Wow!"", the masses cried";
             ref int maxCount, // Pass by reference
             out int count)
         {
-			//the argument passed in as 'count' will hold the value of 15 outside of this function
-            count = 15; // out param must be assigned before control leaves the method
+		//the argument passed in as 'count' will hold the value of 15 outside of this function
+		count = 15; // out param must be assigned before control leaves the method
         }
 
         // GENERICS

--- a/elixir.html.markdown
+++ b/elixir.html.markdown
@@ -384,6 +384,8 @@ end
 
 # Compile the module and create a process that evaluates `area_loop` in the shell
 pid = spawn(fn -> Geometry.area_loop() end) #=> #PID<0.40.0>
+#Alternatively
+pid = spawn(Geometry, :area_loop, [])
 
 # Send a message to `pid` that will match a pattern in the receive statement
 send pid, {:rectangle, 2, 3}


### PR DESCRIPTION
I tried clarifying that any parameter passed in as an out parameter will hold the value assigned to it outside of the scope of the function.

I noticed weird spacing issues after my commit, so I fixed them.