### PR TITLE
Typo fixes and refactor description of Java Map

### DIFF
--- a/java.html.markdown
+++ b/java.html.markdown
@@ -7,6 +7,7 @@ contributors:
     - ["Simon Morgan", "http://sjm.io/"]
     - ["Zachary Ferguson", "http://github.com/zfergus2"]
     - ["Cameron Schermerhorn", "http://github.com/cschermerhorn"]
+    - ["Rachel Stiyer", "https://github.com/rstiyer"]
 filename: LearnJava.java
 ---
 
@@ -137,7 +138,7 @@ public class LearnJava {
         //
         // BigDecimal allows the programmer complete control over decimal
         // rounding. It is recommended to use BigDecimal with currency values
-        // and where exact decimal percision is required.
+        // and where exact decimal precision is required.
         //
         // BigDecimal can be initialized with an int, long, double or String
         // or by initializing the unscaled value (BigInteger) and scale (int).
@@ -184,8 +185,12 @@ public class LearnJava {
         // LinkedLists - Implementation of doubly-linked list. All of the
         //               operations perform as could be expected for a
         //               doubly-linked list.
-        // Maps - A set of objects that maps keys to values. A map cannot
-        //        contain duplicate keys; each key can map to at most one value.
+        // Maps - A set of objects that map keys to values. Map is
+	//        an interface and therefore cannot be instantiated.
+	//        The type of keys and values contained in a Map must
+	//        be specified upon instantiation of the implementing
+        //        class. Each key may map to only one corresponding value,
+        //        and each key may appear only once (no duplicates).
         // HashMaps - This class uses a hashtable to implement the Map
         //            interface. This allows the execution time of basic
         //            operations, such as get and insert element, to remain

--- a/xml.html.markdown
+++ b/xml.html.markdown
@@ -3,6 +3,7 @@ language: xml
 filename: learnxml.xml
 contributors:
   - ["João Farias", "https://github.com/JoaoGFarias"]
+  - ["Rachel Stiyer", "https://github.com/rstiyer"]
 ---
 
 XML is a markup language designed to store and transport data.
@@ -65,12 +66,12 @@ Unlike HTML, XML does not specify how to display or to format data, it just carr
 
 * Well-Formated Document x Validation
 
-A XML document is well-formated if it is syntactically correct.
+An XML document is well-formatted if it is syntactically correct.
 However, it is possible to inject more constraints in the document,
 using document definitions, such as DTD and  XML Schema.
 
-A XML document which follows a document definition is called valid,
-regarding that document.
+An XML document which follows a document definition is called valid,
+in regards to that document.
 
 With this tool, you can check the XML data outside the application logic.
 


### PR DESCRIPTION
Fixed a few minor typos and refactored the wording of Map definition so it did not plagarize JavaDocs