### PR TITLE
[python/en] Adding documentation on ternary operator

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -165,6 +165,7 @@ some_var  # => 5
 some_other_var  # Raises a name error
 
 # if can be used as an expression
+# Equivalent of C's '?:' ternary operator
 "yahoo!" if 3 > 2 else 2  # => "yahoo!"
 
 # Lists store sequences


### PR DESCRIPTION
Adding documentation on C's '?:' ternary operator equivalent in Python. 
Since, a lot of people from C/C++/Java might use this documentation, they would look for a ternary operator equivalent in Python. 
This was not mentioned explicitly, even though ternary operator is used in the documentation.

What do you think? @levibostian, @adambard. Please let me know. Thanks.  