### PR TITLE
[README] Fix typo in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ commented code and explained as they go.
 
 ... to write more inline code tutorials. Just grab an existing file from
 this repo and copy the formatting (don't worry, it's all very simple).
-Make a new file, send a pull request, and if it passes master I'll get it up pronto.
+Make a new file, send a pull request, and if it passes muster I'll get it up pronto.
 Remember to fill in the "contributors" fields so you get credited
 properly!
 

--- a/latex.html.markdown
+++ b/latex.html.markdown
@@ -106,7 +106,7 @@ Here's how you state all y that belong to X, $\forall$ x $\in$ X. \\
 % The opposite also holds true. Variable can also be rendered in math-mode.
 
 My favorite Greek letter is $\xi$. I also like $\beta$, $\gamma$ and $\sigma$.
-I haven't found a Greek letter that yet that LaTeX doesn't know about!
+I haven't found a Greek letter yet that LaTeX doesn't know about!
 
 Operators are essential parts of a mathematical document: 
 trigonometric functions ($\sin$, $\cos$, $\tan$), 

--- a/latex.html.markdown
+++ b/latex.html.markdown
@@ -106,7 +106,7 @@ Here's how you state all y that belong to X, $\forall$ x $\in$ X. \\
 % The opposite also holds true. Variable can also be rendered in math-mode.
 
 My favorite Greek letter is $\xi$. I also like $\beta$, $\gamma$ and $\sigma$.
-I haven't found a Greek letter yet that LaTeX doesn't know about!
+I haven't found a Greek letter that yet that LaTeX doesn't know about!
 
 Operators are essential parts of a mathematical document: 
 trigonometric functions ($\sin$, $\cos$, $\tan$), 


### PR DESCRIPTION
Corrects "passes master" to "passes muster" in the README. Minor typo.