### PR TITLE
[python3/en] Adding documentation on ternary operator

### DIFF
--- a/python3.html.markdown
+++ b/python3.html.markdown
@@ -174,6 +174,10 @@ some_var  # => 5
 # See Control Flow to learn more about exception handling.
 some_unknown_var  # Raises a NameError
 
+# if can be used as an expression
+# Equivalent of C's '?:' ternary operator
+"yahoo!" if 3 > 2 else 2  # => "yahoo!"
+
 # Lists store sequences
 li = []
 # You can start with a prefilled list


### PR DESCRIPTION
Adding documentation on C's '?:' ternary operator equivalent in Python 3.

This is similar to the PR #1560, which was about adding ternary operator documentation in Python 2.7.
Please review this. @levibostian. Thanks.  