### PR TITLE
[php/en] Un-beef a comment block closing

### DIFF
--- a/php.html.markdown
+++ b/php.html.markdown
@@ -723,7 +723,7 @@ $cls = new SomeOtherNamespace\MyClass();
 /**********************
 * Late Static Binding
 *
-* /
+*/
 
 class ParentClass {
     public static function who() {


### PR DESCRIPTION
Somebody beefed a closing on the 'Late Static Binding' Comment block, causing the next 18 or so lines to be included in the comment instead of parsed for syntax properly.