### PR TITLE
Add one more string formatting example

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -128,6 +128,7 @@ not False  # => True
 
 # A newer way to format strings is the format method.
 # This method is the preferred way
+"{} is a {}".format("This", "placeholder")
 "{0} can be {1}".format("strings", "formatted")
 # You can use keywords if you don't want to count.
 "{name} wants to eat {food}".format(name="Bob", food="lasagna")


### PR DESCRIPTION
String templates doesn't need to have a number of keyword to format.