### PR TITLE
[rust/en] Updating comment examples

### DIFF
--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -2,6 +2,7 @@
 language: rust
 contributors:
     - ["P1start", "http://p1start.github.io/"]
+    - ["Pink401k", "http://github.com/Pink401k"]
 filename: learnrust.rs
 ---
 
@@ -27,8 +28,15 @@ concepts that are generally found in higher-level languages. This makes
 Rust not only fast, but also easy and efficient to code in.
 
 ```rust
-// This is a comment. Single-line look like this...
-/* ...and multi-line comment look like this */
+// This is a comment. Line comments look like this...
+// and extend multiple lines like this.
+
+/// Documentation comments look like this and support markdown notation.
+/// # Examples
+///
+/// ```
+/// let five = 5
+/// ```
 
 ///////////////
 // 1. Basics //


### PR DESCRIPTION
Small tweak to get the comment bit to be updated per https://doc.rust-lang.org/book/comments.html.

`/* */` comments no longer exist.

Multiline comments just use `//` on each line, and the `///` comments are for documentation (which can include markdown)