### PR TITLE
[haskell/de] [yaml/de] Fix umlauts

### DIFF
--- a/de-de/haskell-de.html.markdown
+++ b/de-de/haskell-de.html.markdown
@@ -59,7 +59,7 @@ not False -- True
 -- Strings und Zeichen
 "Das ist ein String."
 'a' -- Zeichen
-'Einfache Anfuehrungszeichen gehen nicht.' -- error!
+'Einfache Anführungszeichen gehen nicht.' -- error!
 
 -- Strings können konkateniert werden.
 "Hello " ++ "world!" -- "Hello world!"
@@ -90,11 +90,11 @@ not False -- True
 -- Der "!!"-Operator extrahiert das Element an einem bestimmten Index:
 [1..10] !! 3 -- 4
 
--- Haskell unterstuetzt unendliche Listen!
-[1..] -- Die Liste aller natuerlichen Zahlen
+-- Haskell unterstützt unendliche Listen!
+[1..] -- Die Liste aller natürlichen Zahlen
 
 -- Unendliche Listen funktionieren in Haskell, da es "lazy evaluation"
--- unterstuetzt. Haskell evaluiert erst etwas, wenn es benötigt wird.
+-- unterstützt. Haskell evaluiert erst etwas, wenn es benötigt wird.
 -- Somit kannst du nach dem 1000. Element fragen und Haskell gibt es dir:
 
 [1..] !! 999 -- 1000
@@ -106,7 +106,7 @@ not False -- True
 -- Zwei Listen konkatenieren
 [1..5] ++ [6..10]
 
--- Ein Element als Head hinzufuegen
+-- Ein Element als Head hinzufügen
 0:[1..5] -- [0, 1, 2, 3, 4, 5]
 
 -- Weitere Listenoperationen
@@ -152,7 +152,7 @@ add 1 2 -- 3
 (//) a b = a `div` b
 35 // 4 -- 8
 
--- Guards sind eine einfache Möglichkeit fuer Fallunterscheidungen.
+-- Guards sind eine einfache Möglichkeit für Fallunterscheidungen.
 fib x
   | x < 2 = 1
   | otherwise = fib (x - 1) + fib (x - 2)
@@ -186,7 +186,7 @@ foldl1 (\acc x -> acc + x) [1..5] -- 15
 -- 4. Mehr Funktionen
 ----------------------------------------------------
 
--- currying: Wenn man nicht alle Argumente an eine Funktion uebergibt,
+-- currying: Wenn man nicht alle Argumente an eine Funktion übergibt,
 -- so wird sie eine neue Funktion gebildet ("curried").
 -- Es findet eine partielle Applikation statt und die neue Funktion
 -- nimmt die fehlenden Argumente auf.
@@ -209,7 +209,7 @@ foo = (*4) . (+10)
 foo 5 -- 60
 
 
--- Haskell hat einen Operator `$`, welcher Funktionsapplikation durchfuehrt.
+-- Haskell hat einen Operator `$`, welcher Funktionsapplikation durchführt.
 -- Im Gegenzug zu der Standard-Funktionsapplikation, welche linksassoziativ ist
 -- und die höchstmögliche Priorität von "10" hat, ist der `$`-Operator
 -- rechtsassoziativ und hat die Priorität 0. Dieses hat (idr.) den Effekt,
@@ -238,14 +238,14 @@ even . fib $ 7 -- false
 True :: Bool
 
 -- Funktionen haben genauso Typen.
--- `not` ist Funktion die ein Bool annimmt und ein Bool zurueckgibt:
+-- `not` ist Funktion die ein Bool annimmt und ein Bool zurückgibt:
 -- not :: Bool -> Bool
 
 -- Eine Funktion die zwei Integer Argumente annimmt:
 -- add :: Integer -> Integer -> Integer
 
 -- Es ist guter Stil zu jeder Funktionsdefinition eine
--- Typdefinition darueber zu schreiben:
+-- Typdefinition darüber zu schreiben:
 double :: Integer -> Integer
 double x = x * 2
 
@@ -317,7 +317,7 @@ data Maybe a = Nothing | Just a
 -- Diese sind alle vom Typ Maybe:
 Just "hello"    -- vom Typ `Maybe String`
 Just 1          -- vom Typ `Maybe Int`
-Nothing         -- vom Typ `Maybe a` fuer jedes `a`
+Nothing         -- vom Typ `Maybe a` für jedes `a`
 
 ----------------------------------------------------
 -- 8. Haskell IO
@@ -326,8 +326,8 @@ Nothing         -- vom Typ `Maybe a` fuer jedes `a`
 -- IO kann nicht völlig erklärt werden ohne Monaden zu erklären,
 -- aber man kann die grundlegenden Dinge erklären.
 
--- Wenn eine Haskell Programm ausgefuehrt wird, so wird `main` aufgerufen.
--- Diese muss etwas vom Typ `IO ()` zurueckgeben. Zum Beispiel:
+-- Wenn eine Haskell Programm ausgeführt wird, so wird `main` aufgerufen.
+-- Diese muss etwas vom Typ `IO ()` zurückgeben. Zum Beispiel:
 
 main :: IO ()
 main = putStrLn $ "Hello, sky! " ++ (say Blue)
@@ -355,10 +355,10 @@ sayHello = do
                    -- an die Variable "name" gebunden
    putStrLn $ "Hello, " ++ name
 
--- Uebung: Schreibe deine eigene Version von `interact`,
+-- Übung: Schreibe deine eigene Version von `interact`,
 -- die nur eine Zeile einliest.
 
--- `sayHello` wird niemals ausgefuehrt, nur `main` wird ausgefuehrt.
+-- `sayHello` wird niemals ausgeführt, nur `main` wird ausgeführt.
 -- Um `sayHello` laufen zulassen kommentiere die Definition von `main`
 -- aus und ersetze sie mit:
 --     main = sayHello
@@ -376,7 +376,7 @@ action = do
    input1 <- getLine
    input2 <- getLine
    -- Der Typ von `do` ergibt sich aus der letzten Zeile.
-   -- `return` ist eine Funktion und keine Schluesselwort
+   -- `return` ist eine Funktion und keine Schlüsselwort
    return (input1 ++ "\n" ++ input2) -- return :: String -> IO String
 
 -- Nun können wir `action` wie `getLine` benutzen:
@@ -387,7 +387,7 @@ main'' = do
     putStrLn result
     putStrLn "This was all, folks!"
 
--- Der Typ `IO` ist ein Beispiel fuer eine Monade.
+-- Der Typ `IO` ist ein Beispiel für eine Monade.
 -- Haskell benutzt Monaden Seiteneffekte zu kapseln und somit
 -- eine rein funktional Sprache zu sein.
 -- Jede Funktion die mit der Außenwelt interagiert (z.B. IO)
@@ -404,7 +404,7 @@ main'' = do
 
 -- Starte die REPL mit dem Befehl `ghci`
 -- Nun kann man Haskell Code eingeben.
--- Alle neuen Werte muessen mit `let` gebunden werden:
+-- Alle neuen Werte müssen mit `let` gebunden werden:
 
 let foo = 5
 
@@ -413,7 +413,7 @@ let foo = 5
 >:t foo
 foo :: Integer
 
--- Auch jede `IO ()` Funktion kann ausgefuehrt werden.
+-- Auch jede `IO ()` Funktion kann ausgeführt werden.
 
 > sayHello
 What is your name?
@@ -437,6 +437,6 @@ qsort (p:xs) = qsort lesser ++ [p] ++ qsort greater
 Haskell ist sehr einfach zu installieren.
 Hohl es dir von [hier](http://www.haskell.org/platform/).
 
-Eine sehr viele langsamere Einfuehrung findest du unter:
+Eine sehr viele langsamere Einführung findest du unter:
 [Learn you a Haskell](http://learnyouahaskell.com/) oder
 [Real World Haskell](http://book.realworldhaskell.org/).

--- a/de-de/yaml-de.html.markdown
+++ b/de-de/yaml-de.html.markdown
@@ -30,7 +30,7 @@ null_Wert: null
 Schlüssel mit Leerzeichen: value
 # Strings müssen nicht immer mit Anführungszeichen umgeben sein, können aber:
 jedoch: "Ein String in Anführungzeichen"
-"Ein Schlüssel in Anführungszeichen": "Nützlich, wenn du einen Doppelpunkt im Schluessel haben willst."
+"Ein Schlüssel in Anführungszeichen": "Nützlich, wenn du einen Doppelpunkt im Schlüssel haben willst."
 
 # Mehrzeilige Strings schreibst du am besten als 'literal block' (| gefolgt vom Text)
 # oder ein 'folded block' (> gefolgt vom text).
@@ -64,7 +64,7 @@ eine_verschachtelte_map:
         hallo: hallo
 
 # Schlüssel müssen nicht immer String sein.
-0.25: ein Float-Wert als Schluessel
+0.25: ein Float-Wert als Schlüssel
 
 # Schlüssel können auch mehrzeilig sein, ? symbolisiert den Anfang des Schlüssels
 ? |


### PR DESCRIPTION
Replaced ae/oe/ue with ä/ö/ü where appropriate.

I did a "grep" in the de-de directory, i've only found
problems in haskell and yaml files.