### PR TITLE
[julia/en] Fix a typo is julia.html.markdown

### DIFF
--- a/julia.html.markdown
+++ b/julia.html.markdown
@@ -2,6 +2,7 @@
 language: Julia
 contributors:
     - ["Leah Hanson", "http://leahhanson.us"]
+    - ["Pranit Bauva", "http://github.com/pranitbauva1997"]
 filename: learnjulia.jl
 ---
 

--- a/julia.html.markdown
+++ b/julia.html.markdown
@@ -723,7 +723,7 @@ code_native(square_area, (Float64,))
 	#	    ret
 	#
 # Note that julia will use floating point instructions if any of the
-# arguements are floats.
+# arguments are floats.
 # Let's calculate the area of a circle
 circle_area(r) = pi * r * r     # circle_area (generic function with 1 method)
 circle_area(5)                  # 78.53981633974483


### PR DESCRIPTION
A small typo mistake "arguements" -> "arguments"