### PR TITLE
[Ruby] Adds JF to contributors

### DIFF
--- a/ruby.html.markdown
+++ b/ruby.html.markdown
@@ -14,6 +14,7 @@ contributors:
   - ["Rahil Momin", "https://github.com/iamrahil"]
   - ["Gabriel Halley", "https://github.com/ghalley"]
   - ["Persa Zula", "http://persazula.com"]
+  - ["Jake Faris", "https://github.com/farisj"]
 ---
 
 ```ruby


### PR DESCRIPTION
As per these two merged PRs ([#1](https://github.com/adambard/learnxinyminutes-docs/pull/1908), [#2](https://github.com/adambard/learnxinyminutes-docs/pull/1909)), adds Jake Faris as a contributor to the Ruby file.