### PR TITLE
[python3/en] Correct math.sqrt(16)

### DIFF
--- a/python3.html.markdown
+++ b/python3.html.markdown
@@ -689,7 +689,7 @@ i.age  # => raises an AttributeError
 
 # You can import modules
 import math
-print(math.sqrt(16))  # => 4
+print(math.sqrt(16))  # => 4.0
 
 # You can get specific functions from a module
 from math import ceil, floor


### PR DESCRIPTION
`math.sqrt(16)` returns `4.0` instead of `4`