### PR TITLE
[markdown/fr] Corrects the filename

### DIFF
--- a/fr-fr/markdown.html.markdown
+++ b/fr-fr/markdown.html.markdown
@@ -2,7 +2,7 @@
 language: markdown
 contributors:
 - ["Andrei Curelaru", "http://www.infinidad.fr"]
-filename: markdown.md
+filename: markdown-fr.md
 lang: fr-fr
 ---
 


### PR DESCRIPTION
Currently, the file name causes the French version to override the original one.