### PR TITLE
Perl6: $! is not available inside the CATCH{} (Possibly)

### DIFF
--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -738,7 +738,7 @@ try {
 # You can throw an exception using `die`:
 die X::AdHoc.new(payload => 'Error !');
 
-# You can access the last exception with `$!` (usually used in a `CATCH` block)
+# You can access the last exception with `$!` (use `$_` in a `CATCH` block)
 
 # There are also some subtelties to exceptions. Some Perl 6 subs return a `Failure`,
 #  which is a kind of "unthrown exception". They're not thrown until you tried to look


### PR DESCRIPTION
I made this PR based on this conversation: http://irclog.perlgeek.de/perl6/2015-11-17#i_11554028 but when I tried to come up with a shorter example, I couldn't reproduce the `$!` not being set inside the `CATCH`, so now I'm unsure whether this PR is correct.

I'll leave it up to you to see whether the correction is needed.