### PR TITLE
[C#/en] Grammar/clarity update in comments about File Naming

### DIFF
--- a/csharp.html.markdown
+++ b/csharp.html.markdown
@@ -45,8 +45,8 @@ using System.Data.Entity;
 // Using this code from another source file: using Learning.CSharp;
 namespace Learning.CSharp
 {
-    // Each .cs file should at least contain a class with the same name as the file
-    // you're allowed to do otherwise, but shouldn't for sanity.
+    // Each .cs file should at least contain a class with the same name as the file.
+    // You're allowed to do otherwise, but shouldn't for sanity.
     public class LearnCSharp
     {
         // BASIC SYNTAX - skip to INTERESTING FEATURES if you have used Java or C++ before


### PR DESCRIPTION
Clarified grammar in LearnCSharp comment about naming files relative to the classes they contain. Otherwise the two comment lines blended together and were a little confusing. 