### PR TITLE
[markdown/cz] Fix missing 'lang' in front matter

### DIFF
--- a/cs-cz/markdown.html.markdown
+++ b/cs-cz/markdown.html.markdown
@@ -5,6 +5,7 @@ contributors:
 translators:
     - ["Michal Martinek", "https://github.com/MichalMartinek"]
 filename: markdown.md
+lang: cs-cz
 ---
 
 Markdown byl vytvořen Johnem Gruberem v roce 2004. Je zamýšlen jako lehce čitelná


### PR DESCRIPTION
I haven't tested this patch, but it seems that the missing parameter is causing 'markdown' to be displayed twice on the front page.

Thanks for awesome work btw!