### PR TITLE
ColdFusion replaced &lt; and &gt; in pre block

### DIFF
--- a/coldfusion.html.markdown
+++ b/coldfusion.html.markdown
@@ -233,40 +233,38 @@ ColdFusion started as a tag-based language. Almost all functionality is availabl
 
 <em>Code for reference (Functions must return something to support IE)</em>
 
-<pre>
-&lt;cfcomponent&gt;
-	&lt;cfset this.hello = "Hello" /&gt;
-	&lt;cfset this.world = "world" /&gt;
+<cfcomponent>
+	<cfset this.hello = "Hello" />
+	<cfset this.world = "world" />
 
-	&lt;cffunction name="sayHello"&gt;
-		&lt;cfreturn this.hello & ", " & this.world & "!" /&gt;
-	&lt;/cffunction&gt;
+	<cffunction name="sayHello">
+		<cfreturn this.hello & ", " & this.world & "!" />
+	</cffunction>
 	
-	&lt;cffunction name="setHello"&gt;
-		&lt;cfargument name="newHello" type="string" required="true" /&gt;
+	<cffunction name="setHello">
+		<cfargument name="newHello" type="string" required="true" />
 		
-		&lt;cfset this.hello = arguments.newHello /&gt;
+		<cfset this.hello = arguments.newHello />
 		 
-		&lt;cfreturn true /&gt;
-	&lt;/cffunction&gt;
+		<cfreturn true />
+	</cffunction>
 	
-	&lt;cffunction name="setWorld"&gt;
-		&lt;cfargument name="newWorld" type="string" required="true" /&gt;
+	<cffunction name="setWorld">
+		<cfargument name="newWorld" type="string" required="true" />
 		
-		&lt;cfset this.world = arguments.newWorld /&gt;
+		<cfset this.world = arguments.newWorld />
 		 
-		&lt;cfreturn true /&gt;
-	&lt;/cffunction&gt;
+		<cfreturn true />
+	</cffunction>
 	
-	&lt;cffunction name="getHello"&gt;
-		&lt;cfreturn this.hello /&gt;
-	&lt;/cffunction&gt;
+	<cffunction name="getHello">
+		<cfreturn this.hello />
+	</cffunction>
 	
-	&lt;cffunction name="getWorld"&gt;
-		&lt;cfreturn this.world /&gt;
-	&lt;/cffunction&gt;
-&lt;/cfcomponent&gt;
-</pre>
+	<cffunction name="getWorld">
+		<cfreturn this.world />
+	</cffunction>
+</cfcomponent>
 
 <cfset this.hello = "Hello" />
 <cfset this.world = "world" />


### PR DESCRIPTION
The pre block was already inside a pre/code block in the rendered page, making it harder to read as they weren't being converted to the corresponding brackets (< or >).

Here's what I was seeing in the rendered page:
![image](https://cloud.githubusercontent.com/assets/622118/11900319/cf7c09d6-a56a-11e5-8df1-c3793d5bf326.png)
