### PR TITLE
[perl 6] changed code output to as stated in comments

### DIFF
--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -803,9 +803,8 @@ module Foo::Bar {
     my sub unavailable { # `my sub` is the default
       say "Can't access me from outside, I'm my !";
     }
+    say ++$n; # increment the package variable and output its value
   }
-
-  say ++$n; # lexically-scoped variables are still available
 }
 say $Foo::Bar::n; #=> 1
 Foo::Bar::inc; #=> 2


### PR DESCRIPTION
The comments state that Foo::Bar::inc in the package variable example should increase $Foo::Bar::n and then print it.
This did not happen, as `say ++$n;` was placed outside the block of the sub Foo::Bar::inc.
The commit puts `say ++$n;` inside the block of Foo::Bar::inc.