### PR TITLE
[swift/en] Updated documentation syntax - small fix

### DIFF
--- a/swift.html.markdown
+++ b/swift.html.markdown
@@ -221,9 +221,9 @@ A greet operation
 - A bullet in docs
 - Another bullet in the docs
 
-:param: name A name
-:param: day A day
-:returns: A string containing the name and day value.
+- Parameter name	: A name
+- Parameter day	: A day
+- Returns : A string containing the name and day value.
 */
 func greet(name: String, day: String) -> String {
     return "Hello \(name), today is \(day)."


### PR DESCRIPTION
As Xcode switched to Markdown syntax, I've updated it.
Based on http://nshipster.com/swift-documentation/