### PR TITLE
[Swift/en] Deleted semicolon to be consistent - Small Fix

### DIFF
--- a/swift.html.markdown
+++ b/swift.html.markdown
@@ -392,7 +392,7 @@ testTryStuff()
 
 public class Shape {
     public func getArea() -> Int {
-        return 0;
+        return 0
     }
 }
 


### PR DESCRIPTION
this line 
let weak = "keyword"; let override = "another keyword" // statements can be separated by a semi-colon
show off semicolon use. But after that semicolon is not used, so I removed inconsistency.