### PR TITLE
memoize not memorize

### DIFF
--- a/groovy.html.markdown
+++ b/groovy.html.markdown
@@ -280,7 +280,7 @@ def clos = { print it }
 clos( "hi" )
 
 /*
-  Groovy can memorize closure results [1][2][3]
+  Groovy can memoize closure results [1][2][3]
 */
 def cl = {a, b ->
     sleep(3000) // simulate some time consuming processing


### PR DESCRIPTION
Let's use the correct term instead of the tongue-in-cheek term denoting the same concept.