### PR TITLE
Fixing broken link to Elixir's Getting Started documentation

### DIFF
--- a/elixir.html.markdown
+++ b/elixir.html.markdown
@@ -411,7 +411,7 @@ self() #=> #PID<0.27.0>
 
 ## References
 
-* [Getting started guide](http://elixir-lang.org/getting_started/1.html) from [elixir webpage](http://elixir-lang.org)
+* [Getting started guide](http://elixir-lang.org/getting-started/introduction.html) from the [Elixir website](http://elixir-lang.org)
 * [Elixir Documentation](http://elixir-lang.org/docs/master/)
 * ["Programming Elixir"](https://pragprog.com/book/elixir/programming-elixir) by Dave Thomas
 * [Elixir Cheat Sheet](http://media.pragprog.com/titles/elixir/ElixirCheat.pdf)


### PR DESCRIPTION
Just fixing a broken link but to an important learning resource.