### PR TITLE
[exlixir/en] Unclear statement on variable scope

### DIFF
--- a/elixir.html.markdown
+++ b/elixir.html.markdown
@@ -170,7 +170,7 @@ case {:one, :two} do
   {:four, :five} ->
     "This won't match"
   {:one, x} ->
-    "This will match and bind `x` to `:two`"
+    "This will match and bind `x` to `:two` in this clause"
   _ ->
     "This will match any value"
 end


### PR DESCRIPTION
In Elixir, a variable is only bound within the scope where it is declared.
In particular, a variable matched within a `case` statement will not be bound outside of the statement, see [official tutorial](http://elixir-lang.org/getting-started/case-cond-and-if.html#case).