### PR TITLE
[perl6/en] Fixed instance where wrong variable name was used

### DIFF
--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -824,7 +824,7 @@ say why-not[^5]; #=> 5 15 25 35 45
 # (they exist in other langages such as C as `static`)
 sub fixed-rand {
   state $val = rand;
-  say $rand;
+  say $val;
 }
 fixed-rand for ^10; # will print the same number 10 times
 


### PR DESCRIPTION
The name of the variable used is $val, but the code calls say $rand. This pull request corrects that.