### PR TITLE
[c/en] issue 2205: Change variable 'size' to 'array_size'

### DIFF
--- a/c.html.markdown
+++ b/c.html.markdown
@@ -143,9 +143,9 @@ int main (int argc, char** argv)
   // can be declared as well. The size of such an array need not be a compile
   // time constant:
   printf("Enter the array size: "); // ask the user for an array size
-  int size;
-  fscanf(stdin, "%d", &size);
-  int var_length_array[size]; // declare the VLA
+  int array_size;
+  fscanf(stdin, "%d", &array_size);
+  int var_length_array[array_size]; // declare the VLA
   printf("sizeof array = %zu\n", sizeof var_length_array);
 
   // Example:


### PR DESCRIPTION
This is a fix for the English C page, which used two variables both named "size".  I don't anticipate this happening too often, but if someone were to copy and paste the entire file and try to compile it, an error will spring up.  To ease this burden, I changed one of the variables to "array_size", as the role of the variable was to demonstrate variable length arrays based on user input.