### PR TITLE
[latex/en] Replace invite sign $ by > in compilation example

### DIFF
--- a/latex.html.markdown
+++ b/latex.html.markdown
@@ -212,7 +212,7 @@ Getting to the final document using LaTeX consists of the following steps:
     \item Compile source code to produce a pdf. 
      The compilation step looks something like this (in Linux): \\
      \begin{verbatim} 
-        $pdflatex learn-latex.tex learn-latex.pdf 
+        > pdflatex learn-latex.tex learn-latex.pdf 
      \end{verbatim}
   \end{enumerate}
 


### PR DESCRIPTION
Using the $ sign for invite command in the `verbatim` environment messes with syntax highlighting, which stays in math mode for the rest of the document. Using > is an easy fix.