### PR TITLE
Update javascript-es.html.markdown

### DIFF
--- a/es-es/javascript-es.html.markdown
+++ b/es-es/javascript-es.html.markdown
@@ -16,7 +16,7 @@ con Java para aplicaciones más complejas. Debido a su integracion estrecha con 
 web y soporte por defecto de los navegadores modernos se ha vuelto mucho más común 
 para front-end que Java.
 
-Aunque JavaScript no sólo se limita a los navegadores web: Node.js, Un proyecto que proporciona un entorno de ejecución independiente para el motor V8 de Google Chrome, se está volviendo más y más popular.
+Sin embargo, JavaScript no sólo se limita a los navegadores web: Node.js, un proyecto que proporciona un entorno de ejecución independiente para el motor V8 de Google Chrome, se está volviendo más y más popular.
 
 ¡La retroalimentación es bienvenida! Puedes encontrarme en: 
 [@adambrenecki](https://twitter.com/adambrenecki), o
@@ -82,13 +82,13 @@ false;
 !true; // = false
 !false; // = true
 
-// Para comprobar una igualdad se usa ==
-1 == 1; // = true
-2 == 1; // = false
+// Para comprobar una igualdad se usa ===
+1 === 1; // = true
+2 === 1; // = false
 
-// Para comprobar una desigualdad se usa !=
-1 != 1; // = false
-2 != 1; // = true
+// Para comprobar una desigualdad se usa !==
+1 !== 1; // = false
+2 !== 1; // = true
 
 // Más comparaciones
 1 < 10; // = true


### PR DESCRIPTION
@vendethiel, created a new pr based on #1776, with the updates requested on your comments.

I deleted the original fork eons ago and this felt like the easiest way to address them.

Changed:

1. The conjunction, to match the original meaning (in the English article) and the context. The original word was "though", which better resembles "however" ("sin embargo" in spanish). "Aunque" is commonly used to counter something (expressed in the same sentence), closer to the way someone would use "although". The way the translation is written, it's more of a plain statement (with the conjunction at the beginning of the clause), so "Sin embargo" (however) or "Pero" (but) are better alternatives than "Aunque".
2. An Uppercase [sic] : ) typo.
3. Use of strict triple equals to match the original English article. 