### PR TITLE
[c++/pt-br] Fix some typos

### DIFF
--- a/pt-br/c++-pt.html.markdown
+++ b/pt-br/c++-pt.html.markdown
@@ -490,7 +490,7 @@ bool doSomethingWithAFile(const char* filename)
 {
     FILE* fh = fopen(filename, "r"); // Abra o arquivo em modo de leitura
     if (fh == nullptr) // O ponteiro retornado é nulo em caso de falha.
-        reuturn false; // Relate o fracasso para o chamador.
+        return false; // Relate o fracasso para o chamador.
 
     // Suponha cada função retorne false, se falhar
     if (!doSomethingWithTheFile(fh)) {
@@ -511,7 +511,7 @@ bool doSomethingWithAFile(const char* filename)
 {
     FILE* fh = fopen(filename, "r");
     if (fh == nullptr)
-        reuturn false;
+        return false;
 
     if (!doSomethingWithTheFile(fh))
         goto failure;


### PR DESCRIPTION
I only fix `reuturn` replacing by `return`.