### PR TITLE
[scala/en] Add example of an int is divided by a double

### DIFF
--- a/scala.html.markdown
+++ b/scala.html.markdown
@@ -88,6 +88,7 @@ true == false // false
 6 / 2   // 3
 6 / 4   // 1
 6.0 / 4 // 1.5
+6 / 4.0 // 1.5
 
 
 // Evaluating an expression in the REPL gives you the type and value of the result


### PR DESCRIPTION
- [x] PR touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] YAML Frontmatter formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Seriously, look at it now. Watch for quotes and double-check field names.

