### PR TITLE
Remove obsolete utf-8 options.

### DIFF
--- a/tmux.html.markdown
+++ b/tmux.html.markdown
@@ -122,10 +122,6 @@ like how .vimrc or init.el are used.
 ### General
 ###########################################################################
 
-# Enable UTF-8
-setw -g utf8 on
-set-option -g status-utf8 on
-
 # Scrollback/History limit
 set -g history-limit 2048
 


### PR DESCRIPTION
These options are no longer valid in recent versions of tmux. See https://github.com/tmux/tmux/issues/230.