### PR TITLE
[elisp/en] Fix tiny typo

### DIFF
--- a/elisp.html.markdown
+++ b/elisp.html.markdown
@@ -194,7 +194,7 @@ filename: learn-emacs-lisp.el
 ;; And evaluate it:
 (greeting "you")
 
-;; Some function are interactive:
+;; Some functions are interactive:
 (read-from-minibuffer "Enter your name: ")
 
 ;; Evaluating this function returns what you entered at the prompt.


### PR DESCRIPTION
This fixes a tiny typo in elisp article.

It says: _Some function are interactive_

It should say: _Some functions are interactive_