### PR TITLE
adding missing lang entries to headers for 3 tutorials

### DIFF
--- a/id-id/markdown.html.markdown
+++ b/id-id/markdown.html.markdown
@@ -4,6 +4,7 @@ contributors:
     - ["Dan Turkel", "http://danturkel.com/"]
 translators:
     - ["Tasya Aditya Rukmana", "http://github.com/tadityar"]
+lang: id-id
 filename: markdown-id.md
 ---
 

--- a/it-it/rust-it.html.markdown
+++ b/it-it/rust-it.html.markdown
@@ -2,6 +2,7 @@
 language: rust
 contributors:
     - ["Carlo Milanesi", "http://github.com/carlomilanesi"]
+lang: it-it
 filename: rust-it.html.markdown
 ---
 

--- a/pt-br/elixir.html.markdown
+++ b/pt-br/elixir.html.markdown
@@ -5,6 +5,7 @@ contributors:
     - ["Dzianis Dashkevich", "https://github.com/dskecse"]
 translators:
     - ["Rodrigo Muniz", "http://github.com/muniz95"]
+lang: pt-br
 filename: learnelixir-pt.ex
 ---
 


### PR DESCRIPTION
These tutorials are appearing as separate entries rather than as translations.
