### PR TITLE
[rust/de] [rust/en] [rust/es] [rust/fr] [rust/cn] Fix comment in Rust docs: box -> mine

### DIFF
--- a/de-de/rust-de.html.markdown
+++ b/de-de/rust-de.html.markdown
@@ -319,7 +319,7 @@ fn main() {
     var = 3;
     let ref_var: &i32 = &var;
 
-    println!("{}", var); // Anders als `box`, `var` kann hier weiter verwendet werden
+    println!("{}", var); // Anders als `mine`, `var` kann hier weiter verwendet werden
     println!("{}", *ref_var);
     // var = 5; // das kompiliert nicht, da `var` ausgeliehen ist
     // *ref_var = 6; // das kompiliert auch nicht, da `ref_var` eine unveränderliche Referenz ist

--- a/fr-fr/rust-fr.html.markdown
+++ b/fr-fr/rust-fr.html.markdown
@@ -285,7 +285,7 @@ fn main() {
     var = 3;
     let ref_var: &i32 = &var;
 
-    println!("{}", var); // Contrairement `box`, `var` peut encore être utilisé
+    println!("{}", var); // Contrairement `mien`, `var` peut encore être utilisé
     println!("{}", *ref_var);
     // Var = 5; // Cela ne compile pas parce que `var` est emprunté.
     // *ref_var = 6; // Ce ne serait pas non plus, parce que `ref_var` est une

--- a/it-it/rust-it.html.markdown
+++ b/it-it/rust-it.html.markdown
@@ -288,7 +288,7 @@ fn main() {
     var = 3;
     let ref_var: &i32 = &var;
 
-    println!("{}", var); // Diversamente da `box`, `var` può ancora essere usato
+    println!("{}", var); // Diversamente da `mio`, `var` può ancora essere usato
     println!("{}", *ref_var);
     // var = 5; // questo non compilerebbe, perché `var` è stato preso in prestito
     // *ref_var = 6; // neanche questo, perché `ref_var` è un riferimento immutabile

--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -286,7 +286,7 @@ fn main() {
     var = 3;
     let ref_var: &i32 = &var;
 
-    println!("{}", var); // Unlike `box`, `var` can still be used
+    println!("{}", var); // Unlike `mine`, `var` can still be used
     println!("{}", *ref_var);
     // var = 5; // this would not compile because `var` is borrowed
     // *ref_var = 6; // this would not either, because `ref_var` is an immutable reference

--- a/zh-cn/rust-cn.html.markdown
+++ b/zh-cn/rust-cn.html.markdown
@@ -268,7 +268,7 @@ fn main() {
     var = 3;
     let ref_var: &i32 = &var;
 
-    println!("{}", var); //不像 `box`, `var` 还可以继续使用
+    println!("{}", var); //不像 `mine`, `var` 还可以继续使用
     println!("{}", *ref_var);
     // var = 5; // 编译报错，因为 `var` 被借用了
     // *ref_var = 6; // 编译报错，因为 `ref_var` 是不可变引用


### PR DESCRIPTION
- [x] PR touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] YAML Frontmatter formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Seriously, look at it now. Watch for quotes and double-check field names.