### PR TITLE
c: init array with string literals not introduced.

### DIFF
--- a/c.html.markdown
+++ b/c.html.markdown
@@ -236,11 +236,9 @@ int main (int argc, char** argv)
   z = (e > f) ? e : f; // => 10 "if e > f return e, else return f."
 
   // Increment and decrement operators:
-  char s[10] = "ILoveC";
   int j = 0;
-  s[j++]; // => "I". Returns the j-th item of s THEN increments value of j.
-  j = 0;
-  s[++j]; // => "L". Increments value of j THEN returns j-th value of s.
+  int s = j++; // Return j THEN increase j. (s -> 0, j -> 1)
+  s = ++j; // Increase j THEN return j. (s -> 2, j -> 2)
   // same with j-- and --j
 
   // Bitwise operators!

--- a/c.html.markdown
+++ b/c.html.markdown
@@ -237,8 +237,8 @@ int main (int argc, char** argv)
 
   // Increment and decrement operators:
   int j = 0;
-  int s = j++; // Return j THEN increase j. (s -> 0, j -> 1)
-  s = ++j; // Increase j THEN return j. (s -> 2, j -> 2)
+  int s = j++; // Return j THEN increase j. (s = 0, j = 1)
+  s = ++j; // Increase j THEN return j. (s = 2, j = 2)
   // same with j-- and --j
 
   // Bitwise operators!

--- a/c.html.markdown
+++ b/c.html.markdown
@@ -236,7 +236,7 @@ int main (int argc, char** argv)
   z = (e > f) ? e : f; // => 10 "if e > f return e, else return f."
 
   // Increment and decrement operators:
-  char *s = "ILoveC";
+  char s[10] = "ILoveC";
   int j = 0;
   s[j++]; // => "I". Returns the j-th item of s THEN increments value of j.
   j = 0;


### PR DESCRIPTION
To avoid using the concept pointer before it has been introduced,
previously it is changed to array.
But as @geoffliu pointed out,
array initialization using string literals is not introduced either.
So this commit uses neither pointer nor array.
Discussing `i++` and `++i` does not need to involve pointer or array.

---
 c.html.markdown | 6 ++----
 1 file changed, 2 insertions(+), 4 deletions(-)