### PR TITLE
fixed low level calls

### DIFF
--- a/solidity.html.markdown
+++ b/solidity.html.markdown
@@ -786,11 +786,13 @@ sha256("def");
 
 // 12. LOW LEVEL FUNCTIONS
 // call - low level, not often used, does not provide type safety
-successBoolean = someContractAddress.call('function_name', 'arg1', 'arg2');
+uint u = 123;
+address a = this;
+successBoolean = someContractAddress.call(bytes4(sha3('function_name(uint256,address)')), u, a);
 
 // callcode - Code at target address executed in *context* of calling contract
 // provides library functionality
-someContractAddress.callcode('function_name');
+successBoolean = someContractAddress.callcode(bytes4(sha3('function_name(uint256,address)')), u, a);
 
 
 // 13. STYLE NOTES

--- a/solidity.html.markdown
+++ b/solidity.html.markdown
@@ -791,8 +791,13 @@ address a = this;
 successBoolean = someContractAddress.call(bytes4(sha3('function_name(uint256,address)')), u, a);
 
 // callcode - Code at target address executed in *context* of calling contract
+// will keep storage that usually resides in someContract in calling contract
 // provides library functionality
 successBoolean = someContractAddress.callcode(bytes4(sha3('function_name(uint256,address)')), u, a);
+
+// delegatecall - same as callcode but additionally impersonates msg.sender
+// msg.sender inside function_name is equal to the one in this outer contract
+successBoolean = someContractAddress.delegatecall(bytes4(sha3('function_name(uint256,address)')), u, a);
 
 
 // 13. STYLE NOTES


### PR DESCRIPTION
- [x] PR touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] YAML Frontmatter formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Seriously, look at it now. Watch for quotes and double-check field names.

the low level calls should encode the function name and parameters when interacting with solidity functions (at least 99% of all cases I assume) as discussed, e.g. http://ethereum.stackexchange.com/questions/8168/understanding-namereg-callregister-myname-style-call-between-contracts
also the return value of `callcode` should be stored