### PR TITLE
Perl6: Explain that Integers Can't be Passed and Modified in Sub's Even If Using `is rw´

### DIFF
--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -193,6 +193,15 @@ sub mutate($n is rw) {
   say "\$n is now $n !";
 }
 
+my $m = 42;
+mutate $m; # $n is now 43 !
+
+# This works because we are passing the container $m to mutate.  If we try
+# to just pass a number instead of passing a variable it won't work because
+# there is no container being passed and integers are immutable by themselves:
+
+mutate 42; # Parameter '$n' expected a writable container, but got Int value
+
 # If what you want a copy instead, use `is copy`.
 
 # A sub itself returns a container, which means it can be marked as rw:

--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -4,7 +4,6 @@ language: perl6
 filename: learnperl6.pl
 contributors:
     - ["vendethiel", "http://github.com/vendethiel"]
-    - ["samcv", "https://gitlab.com/u/samcv/"]
 ---
 
 Perl 6 is a highly capable, feature-rich programming language made for at

--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -4,6 +4,7 @@ language: perl6
 filename: learnperl6.pl
 contributors:
     - ["vendethiel", "http://github.com/vendethiel"]
+    - ["samcv", "https://gitlab.com/u/samcv/"]
 ---
 
 Perl 6 is a highly capable, feature-rich programming language made for at


### PR DESCRIPTION
Perl6: Explain that Integers Can't be Passed and Modified in Sub's Even If Using `is rw´

- [x] PR touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] YAML Frontmatter formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Seriously, look at it now. Watch for quotes and double-check field names.
