### PR TITLE
[clojure-macros/pt_br] Fixing references links positioning

### DIFF
--- a/pt-br/clojure-macros-pt.html.markdown
+++ b/pt-br/clojure-macros-pt.html.markdown
@@ -142,6 +142,8 @@ Você vai querer estar familiarizado com Clojure. Certifique-se de entender tudo
 (inline-2 (1 + (3 / 2) - (1 / 2) + 1))
 ; -> 3 (Na verdade, 3N, desde que o numero ficou convertido em uma fração racional com /
 
+```
+
 ### Leitura adicional
 
 Escrevendo Macros de [Clojure para o Brave e True](http://www.braveclojure.com/)


### PR DESCRIPTION
- [x] PR touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] YAML Frontmatter formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Seriously, look at it now. Watch for quotes and double-check field names.

Links were positioned inside a code block, preventing markdown
to parse links to HTML version