### PR TITLE
typo fix in clojure.html.markdown nth input expression from 4 to 2 re…

### DIFF
--- a/clojure.html.markdown
+++ b/clojure.html.markdown
@@ -297,7 +297,7 @@ keymap ; => {:a 1, :b 2, :c 3}
 
 (as-> [1 2 3] input
   (map inc input);=> You can use last transform's output at the last position
-  (nth input 4) ;=>  and at the second position, in the same expression
+  (nth input 2) ;=>  and at the second position, in the same expression
   (conj [4 5 6] input [8 9 10])) ;=> or in the middle !
 
 


### PR DESCRIPTION
- [x] PR touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] YAML Frontmatter formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Seriously, look at it now. Watch for quotes and double-check field names.

typo fix in clojure.html.markdown nth input expression from 4 to 2 resolves: IndexOutOfBoundsException clojure.lang.RT.nthFrom (RT.java:885)