### PR TITLE
Fix for the three tutorials with broken YAML markup, causing them not to be accessible at all or show up in the index

### DIFF
--- a/ru-ru/markdown-ru.html.markdown
+++ b/ru-ru/markdown-ru.html.markdown
@@ -5,7 +5,7 @@ contributors:
     - ["Jacob Ward", "http://github.com/JacobCWard/"]
 translators:
     - ["Pirogov Alexey", "http://twitter.com/alex_pir"]
-    - ["Andre Polykanine", https://github.com/Oire"]
+    - ["Andre Polykanine", "https://github.com/Oire"]
 filename: markdown-ru.md
 lang: ru-ru
 ---

--- a/ru-ru/typescript-ru.html.markdown
+++ b/ru-ru/typescript-ru.html.markdown
@@ -5,7 +5,7 @@ contributors:
     - ["Philippe Vlérick", "https://github.com/pvlerick"]
 translators:
     - ["Fadil Mamedov", "https://github.com/fadilmamedov"]
-    - "Andre Polykanine", "https://github.com/Oire"]
+    - ["Andre Polykanine", "https://github.com/Oire"]
 filename: learntypescript-ru.ts
 ---
 

--- a/zh-cn/vim-cn.html.markdown
+++ b/zh-cn/vim-cn.html.markdown
@@ -3,9 +3,9 @@ category: tool
 tool: vim
 filename: LearnVim-cn.txt
 contributors:
-    - ["RadhikaG"， "https://github.com/RadhikaG"]
+   - ["RadhikaG", "https://github.com/RadhikaG"]
 translators:
-  - ["Jiang Haiyun"， "https://github.com/haiiiiiyun"]
+   - ["Jiang Haiyun", "https://github.com/haiiiiiyun"]
 lang: zh-cn
 ---
 


### PR DESCRIPTION
- [x] YAML Frontmatter formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Seriously, look at it now. Watch for quotes and double-check field names.

Fix tutorials not generating for the following reasons:
* Missing quotes
* Missing brackets
* Fullwidth commas instead of normal commas