### PR TITLE
fixes bullet/list issues in AngularJS markdown

### DIFF
--- a/angularjs.html.markdown
+++ b/angularjs.html.markdown
@@ -18,9 +18,10 @@ AngularJS extends HTML attributes with Directives, and binds data to HTML with E
 ##What You Should Already Know
 
 Before you study AngularJS, you should have a basic understanding of:
-* HTML
-* CSS
-* JavaScript
+
+- HTML
+- CSS
+- JavaScript
 
 ```html
 // AngularJS is a JavaScript framework. It is a library written in JavaScript.
@@ -279,11 +280,11 @@ angular.module('myApp', []).controller('namesCtrl', function($scope) {
 // Filters can be added to expressions and directives using a pipe character.
 // AngularJS filters can be used to transform data:
 
-**currency:  Format a number to a currency format.
-**filter:  Select a subset of items from an array.
-**lowercase: Format a string to lower case.
-**orderBy: Orders an array by an expression.
-**uppercase: Format a string to upper case.
+- **currency**:  Format a number to a currency format.
+- **filter**:  Select a subset of items from an array.
+- **lowercase**: Format a string to lower case.
+- **orderBy**: Orders an array by an expression.
+- **uppercase**: Format a string to upper case.
 
 //A filter can be added to an expression with a pipe character (|) and a filter.
 //(For the next two examples we will use the person controller from the previous chapter)
@@ -696,13 +697,15 @@ app.controller('myCtrl', function($scope) {
 
 ## Source & References
 
-**Examples
-* http://www.w3schools.com/angular/angular_examples.asp
+**Examples**
 
-**References
-* http://www.w3schools.com/angular/angular_ref_directives.asp
-* http://www.w3schools.com/angular/default.asp
-* https://teamtreehouse.com/library/angular-basics/
+- http://www.w3schools.com/angular/angular_examples.asp
+
+**References**
+
+- http://www.w3schools.com/angular/angular_ref_directives.asp
+- http://www.w3schools.com/angular/default.asp
+- https://teamtreehouse.com/library/angular-basics/
 
 Feedback is welcome! You can find me in:
 [@WalterC_87](https://twitter.com/WalterC_87), or


### PR DESCRIPTION
- [x] PR touches only one file (or a set of logically related files with similar changes made)
- [x] ~~Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)~~
- [x] ~~YAML Frontmatter formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)~~
  - [x] ~~Seriously, look at it now. Watch for quotes and double-check field names.~~

The last three of the above "tasks" don't seem to apply, this is a documentation change, specifically to an existing entry.

There looked to be some confused markdown usage; this has been corrected. For instance, in the first paragraph of the "What You Should Already Know", the list looks okay in the source markdown file on GitHub, but the rendered html page displayed the list items inline with the asterisk. There were a couple other locations, the section on filters and the footer, with resource links, where bolding an attempt at bolding some key words wasn't completed; the ones in the footer had a list of resources, but weren't actually rendered lists, converted.

Example, before, rendered html on live site:
![screen shot 2016-10-30 at 7 51 03 am](https://cloud.githubusercontent.com/assets/622118/19836690/5ae02c14-9e76-11e6-9d38-e8dd75953986.png)