### PR TITLE
C/en formatting fix

### DIFF
--- a/c.html.markdown
+++ b/c.html.markdown
@@ -596,7 +596,7 @@ void function_1()
 {
   struct rectangle my_rec;
 
-  // Access struct members with .
+  // Access struct members with.
   my_rec.width = 10;
   my_rec.height = 20;
 


### PR DESCRIPTION
Space should be removed.
Before:
  // Access struct members with .
After:
  // Access struct members with.