### PR TITLE
[solidity/en] solidity contract name convention CamelCase to CapWords

### DIFF
--- a/solidity.html.markdown
+++ b/solidity.html.markdown
@@ -45,7 +45,7 @@ features are typically marked, and subject to change. Pull requests welcome.
 
 /* 'contract' has similarities to 'class' in other languages (class variables,
 inheritance, etc.) */
-contract SimpleBank { // CamelCase
+contract SimpleBank { // CapWords
     // Declare state variables outside function, persist through life of contract
 
     // dictionary that maps addresses to balances


### PR DESCRIPTION
http://solidity.readthedocs.io/en/develop/style-guide.html#contract-and-library-names
