### PR TITLE
Update Guard Sequences link and change format

### DIFF
--- a/erlang.html.markdown
+++ b/erlang.html.markdown
@@ -183,9 +183,10 @@ is_pet(A)                                             -> false.
 % Warning: not all valid Erlang expressions can be used as guard expressions;
 % in particular, our `is_cat` and `is_dog` functions cannot be used within the
 % guard sequence in `is_pet`'s definition. For a description of the
-% expressions allowed in guard sequences, refer to this
-% [section](http://erlang.org/doc/reference_manual/expressions.html#id81912)
-% of the Erlang reference manual.
+% expressions allowed in guard sequences, refer to the specific section
+% in the Erlang reference manual:
+% http://erlang.org/doc/reference_manual/expressions.html#id84508
+
 
 % Records provide a method for associating a name with a particular element in a
 % tuple.


### PR DESCRIPTION
It updates an old link, and changes the way the URL is formated.
It shouldn't be markdown style as it's inside a comment

- [ ] Pull request title is prepended with `[language/lang-code]`
- [ ] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
