### PR TITLE
[erlang] Update guard sequences URL to use named id

### DIFF
--- a/erlang.html.markdown
+++ b/erlang.html.markdown
@@ -185,7 +185,7 @@ is_pet(A)                                             -> false.
 % guard sequence in `is_pet`'s definition. For a description of the
 % expressions allowed in guard sequences, refer to the specific section
 % in the Erlang reference manual:
-% http://erlang.org/doc/reference_manual/expressions.html#id84508
+% http://erlang.org/doc/reference_manual/expressions.html#guards
 
 
 % Records provide a method for associating a name with a particular element in a


### PR DESCRIPTION
it uses a named id, not a number

- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
