### PR TITLE
[python3/en] Fix two "getter" output examples

### DIFF
--- a/python3.html.markdown
+++ b/python3.html.markdown
@@ -729,8 +729,8 @@ if __name__ == '__main__':
     # Update the property for this instance
     i.age = 42
     # Get the property
-    i.say(i.age)                    # => 42
-    j.say(j.age)                    # => 0
+    i.say(i.age)                    # => "Ian: 42"
+    j.say(j.age)                    # => "Joel: 0"
     # Delete the property
     del i.age
     # i.age                         # => this would raise an AttributeError


### PR DESCRIPTION
Under section 6. Classes, the "getter" examples should return "Ian: 42" and "Joel: 0" respectively instead of integers, since they're wrapped in calls to "say". Here's what's the page said originally:
```
  # Get the property
    i.say(i.age)                    # => 42
    j.say(j.age)                    # => 0
```
Hope this helps!

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
