### PR TITLE
Adds Gemfile.lock to lock charlock_holmes gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    charlock_holmes (0.7.3)
+    rake (12.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  charlock_holmes
+  rake
+
+BUNDLED WITH
+   1.13.7


### PR DESCRIPTION
Makes sure the tests are ran with a working charlock_holmes gem

e.g. prevents this from happening:

https://github.com/brianmario/charlock_holmes/issues/78

- [x] I solemnly swear that this is all original content of which I am the original author
-  Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - Yes, I have double-checked quotes and field names!
