### PR TITLE
[logtalk/it-it] fix typo in example code

### DIFF
--- a/it-it/logtalk-it.html.markdown
+++ b/it-it/logtalk-it.html.markdown
@@ -187,7 +187,7 @@ Un messaggio è valido se il relativo predicato è dichiarato in un oggetto (e s
 ```logtalk
 :- object(foo).
 
-	:- public(bar).
+	:- public(bar/0).
 
 :- end_object.
 ```


### PR DESCRIPTION
- [*] I solemnly swear that this is all original content of which I am the original author
- [*] Pull request title is prepended with `[language/lang-code]`
- [*] Pull request touches only one file (or a set of logically related files with similar changes made)
- [*] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [*] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [*] Yes, I have double-checked quotes and field names!
