### PR TITLE
Updating the PureScript string concatenation.

### DIFF
--- a/purescript.html.markdown
+++ b/purescript.html.markdown
@@ -65,7 +65,7 @@ true && (9 >= 19 || 1 < 2) -- true
 """Hello
 world""" -- "Hello\nworld"
 -- Concatenate
-"such " ++ "amaze" -- "such amaze"
+"such " <> "amaze" -- "such amaze"
 
 --
 -- 2. Arrays are Javascript arrays, but must be homogeneous


### PR DESCRIPTION
https://github.com/purescript/purescript/wiki/Differences-from-Haskell

...says:

> Since 0.9.1, the Prelude library does not contain (++) as a second alias for append / (<>) (mappend in Haskell) anymore.

So:

```
-- Concatenate
"such " ++ "amaze" -- "such amaze"
```

...should read:

```
-- Concatenate
"such " <> "amaze" -- "such amaze"
```

- [ ] I solemnly swear that this is all original content of which I am the original author
- [ ] Pull request title is prepended with `[language/lang-code]`
- [ ] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
