### PR TITLE
[perl/en] Use more single quotes and explain single vs double quotes

### DIFF
--- a/perl.html.markdown
+++ b/perl.html.markdown
@@ -37,9 +37,13 @@ use warnings;
 #  A scalar represents a single value:
 my $animal = "camel";
 my $answer = 42;
+my $display = "You have $answer ${animal}s.\n";
 
 # Scalar values can be strings, integers or floating point numbers, and
 # Perl will automatically convert between them as required.
+
+# Strings in single quotes are literal strings. Strings in double quotes
+# will interpolate variables and escape codes like "\n" for newline.
 
 ## Arrays
 #  An array represents a list of values:

--- a/perl.html.markdown
+++ b/perl.html.markdown
@@ -62,6 +62,18 @@ my $second = $animals[1];
 my $num_animals = @animals;
 print "Number of numbers: ", scalar(@numbers), "\n";
 
+# Arrays can also be interpolated into double-quoted strings, and the
+# elements are separated by a space character by default.
+
+print "We have these numbers: @numbers\n";
+
+# Be careful when using double quotes for strings containing symbols
+# such as email addresses, as it will be interpreted as a variable.
+
+my @example = ('secret', 'array');
+my $oops_email = "foo@example.com"; # 'foosecret array.com'
+my $ok_email = 'foo@example.com';
+
 ## Hashes
 #   A hash represents a set of key/value pairs:
 


### PR DESCRIPTION
It's unnecessary to use double quotes for strings with no variables or escape codes. Also explains an example of variable interpolation in a string.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
