### PR TITLE
[racket/en] Fix Incorrect Names in Mutable Struct Examples (per Issue #2714)

### DIFF
--- a/racket.html.markdown
+++ b/racket.html.markdown
@@ -148,7 +148,7 @@ my-pet ; => #<dog>
 (define burgundy
    (rgba-color 144 0 32 1.0))
 (set-rgba-color-green! burgundy 10)
-(rgba-color-green burgundy) ;=> 10
+(rgba-color-green burgundy) ; => 10
 
 ;;; Pairs (immutable)
 ;; `cons' constructs pairs, `car' and `cdr' extract the first

--- a/racket.html.markdown
+++ b/racket.html.markdown
@@ -147,8 +147,8 @@ my-pet ; => #<dog>
 (struct rgba-color (red green blue alpha) #:mutable)
 (define burgundy
    (rgba-color 144 0 32 1.0))
-(set-color-green! burgundy 10)
-(color-green burgundy) ; => 10
+(set-rgba-color-green! burgundy 10)
+(rgba-color-green burgundy) ;=> 10
 
 ;;; Pairs (immutable)
 ;; `cons' constructs pairs, `car' and `cdr' extract the first


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)

Per #2714 , 

Fixed incorrect name in mutable struct access and setting examples.