### PR TITLE
[zfs/en] Fix bullet points

### DIFF
--- a/zfs.html.markdown
+++ b/zfs.html.markdown
@@ -24,6 +24,7 @@ VDEV's offer better reliability and safety than a RAID card.  It is discouraged 
 RAID setup with ZFS, as ZFS expects to directly manage the underlying disks.
 
 Types of VDEV's
+
 * stripe (a single disk, no redundancy)
 * mirror (n-way mirrors supported)
 * raidz
@@ -60,6 +61,7 @@ single host can have 2^64 storage pools.  The limits are huge.
 ### Storage Pools
 
 Actions:
+
 * List
 * Status
 * Destroy


### PR DESCRIPTION
This commit will fix the incorrect bullet point markdown to allow proper html
generation. The markdown should have a linebreak before the first item of
the list. 

The bullet pointed list currently looks like this:

![image](https://cloud.githubusercontent.com/assets/24862378/26244411/07701fc4-3c7f-11e7-836b-abb16b7c4ddc.png)

The bullet points are not generated and everything is displayed inline.

-----

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)