### PR TITLE
[Javascript/en]Corrects typo in prototype section.

### DIFF
--- a/javascript.html.markdown
+++ b/javascript.html.markdown
@@ -481,7 +481,7 @@ for (var x in myObj){
 }
 ///prints:
 // Hello world!
-// 42
+// 43
 // [Function: myFunc]
 
 // To only consider properties attached to the object itself


### PR DESCRIPTION
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)

This PR contains a commit fixing a typo within the prototype section.  Specifically, a printed version of a variable should be 43, not 42. 