### PR TITLE
[PHP/en]Fix small typo in PHP English tutorial

### DIFF
--- a/php.html.markdown
+++ b/php.html.markdown
@@ -342,7 +342,7 @@ switch ($x) {
 $i = 0;
 while ($i < 5) {
     echo $i++;
-}; // Prints "01234"
+} // Prints "01234"
 
 echo "\n";
 


### PR DESCRIPTION
There is unnecessary semicolon after while loop.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
