### PR TITLE
[scala/en] Make return value example actually demonstrate issue

### DIFF
--- a/scala.html.markdown
+++ b/scala.html.markdown
@@ -253,15 +253,19 @@ weirdSum(2, 4) // => 16
 // def that surrounds it.
 // WARNING: Using return in Scala is error-prone and should be avoided.
 // It has no effect on anonymous functions. For example:
-def foo(x: Int): Int = {
-  val anonFunc: Int => Int = { z =>
+def addTenButMaybeTwelve(x: Int): Int = {
+  val anonMaybeAddTwo: Int => Int = { z =>
     if (z > 5)
-      return z // This line makes z the return value of foo!
+      return z // This line makes z the return value of addTenButMaybeTwelve!
     else
       z + 2    // This line is the return value of anonFunc
   }
-  anonFunc(x)  // This line is the return value of foo
+  anonMaybeAddTwo(x) + 10  // This line is the return value of foo
 }
+
+addTenButMaybeTwelve(2) // Returns 14 as expected: 2 <= 5, adds 12
+addTenButMaybeTwelve(7) // Returns 7: 7 > 5, return value set to z, so
+                        // last line doesn't get called and 10 is not added
 
 
 /////////////////////////////////////////////////

--- a/scala.html.markdown
+++ b/scala.html.markdown
@@ -258,9 +258,9 @@ def addTenButMaybeTwelve(x: Int): Int = {
     if (z > 5)
       return z // This line makes z the return value of addTenButMaybeTwelve!
     else
-      z + 2    // This line is the return value of anonFunc
+      z + 2    // This line is the return value of anonMaybeAddTwo
   }
-  anonMaybeAddTwo(x) + 10  // This line is the return value of foo
+  anonMaybeAddTwo(x) + 10  // This line is the return value of addTenButMaybeTwelve
 }
 
 addTenButMaybeTwelve(2) // Returns 14 as expected: 2 <= 5, adds 12


### PR DESCRIPTION
Solves #2724 

Previously the `return z` didn't actually have any effect on the output, since the outer function just returned the anon function's result directly. Updated to make the outer function do something with the return value to demonstrate the difference. Also renamed functions to make what they're doing easier to follow, and added a couple examples of behavior with accompanying explanations.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
