### PR TITLE
[python3/en] Fix Typo python3.html.markdown

### DIFF
--- a/python3.html.markdown
+++ b/python3.html.markdown
@@ -345,6 +345,7 @@ invalid_set = {[1], 1}  # => Raises a TypeError: unhashable type: 'list'
 valid_set = {(1,), 1}
 
 # Add one more item to the set
+filled_set = some_set
 filled_set.add(5)  # filled_set is now {1, 2, 3, 4, 5}
 
 # Do set intersection with &


### PR DESCRIPTION
'filled_set' was not defined before attempting to add to it, resulting in a NameError. 

Alternative would be to use 'some_set' for all examples and change each instance of 'filled_set' to 'some_set' across lines 348, 352, 355, 370, 371.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
