### PR TITLE
[scala/de] Backport traits keyword explanation

### DIFF
--- a/de-de/scala-de.html.markdown
+++ b/de-de/scala-de.html.markdown
@@ -538,8 +538,9 @@ res2: Boolean = true
 scala> b.beissen  
 res3: Boolean = false  
 
-
-// Traits können auch via Mixins (Schlüsselwort "with") eingebunden werden  
+// Ein Trait kann auch als Mixin eingebunden werden. Die Klasse erbt vom
+// ersten Trait mit dem Schlüsselwort "extends", während weitere Traits
+// mit "with" verwendet werden können.
 
 trait Bellen {
 	def bellen: String = "Woof"


### PR DESCRIPTION
Backport changes made to English translation explaining trait keywords. See #2760

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull requxst touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
