### PR TITLE
[standard-ml/en] Redundancy is not permitted in pattern matching

### DIFF
--- a/standard-ml.html.markdown
+++ b/standard-ml.html.markdown
@@ -351,7 +351,10 @@ val _ = print (say(Red) ^ "\n")
 fun say Red   = "You are red!"
   | say Green = "You are green!"
   | say Blue  = "You are blue!"
-  | say _     = raise Fail "Unknown color"
+
+(* We did not include the match arm `say _ = raise Fail "Unknown color"`
+because after specifying all three colors, the pattern is exhaustive
+and redundancy is not permitted in pattern matching *)
 
 
 (* Here is a binary tree datatype *)


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!

 The REPL complains as follows on specifying the deleted line
```
fun say Red   = "You are red!"
=   | say Green = "You are green!"
=   | say Blue  = "You are blue!"
=   | say _     = raise Fail "Unknown color";
stdIn:171.5-174.43 Error: match redundant
          Red => ...
          Green => ...
          Blue => ...
    -->   _ => ...
```