### PR TITLE
[json/en] add carriage return to fix broken bullet list

### DIFF
--- a/json.html.markdown
+++ b/json.html.markdown
@@ -11,6 +11,7 @@ contributors:
 JSON is an extremely simple data-interchange format. As [json.org](http://json.org) says, it is easy for humans to read and write and for machines to parse and generate.
 
 A piece of JSON must represent either:
+
 * A collection of name/value pairs (`{ }`). In various languages, this is realized as an object, record, struct, dictionary, hash table, keyed list, or associative array.
 * An ordered list of values (`[ ]`). In various languages, this is realized as an array, vector, list, or sequence.
  an array/list/sequence (`[ ]`) or a dictionary/object/associated array (`{ }`).


### PR DESCRIPTION
- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)

I *think* this fixes a broken bullet list on the JSON article. :)
