### PR TITLE
[ru/all] Remove Dolphin's clutter from the repository

### DIFF
--- a/ru-ru/.directory
+++ b/ru-ru/.directory
@@ -1,4 +1,0 @@
-[Dolphin]
-SortRole=size
-Timestamp=2015,10,31,18,6,13
-Version=3


### PR DESCRIPTION
This is a clutter left by [Dolphin file manager](https://userbase.kde.org/Dolphin) which has no use here.