### PR TITLE
[asciidoc/en,de,is,pt] Fixed wrong section titles in AsciiDoc

### DIFF
--- a/asciidoc.html.markdown
+++ b/asciidoc.html.markdown
@@ -82,10 +82,6 @@ Section Titles
 
 ===== Level 4 <h5>
 
-====== Level 5 <h6>
-
-======= Level 6  <h7>
-
 ```
 
 Lists

--- a/de-de/asciidoc-de.html.markdown
+++ b/de-de/asciidoc-de.html.markdown
@@ -84,10 +84,6 @@ Abteilungstitel
 
 ===== Level 4 <h5>
 
-====== Level 5 <h6>
-
-======= Level 6  <h7>
-
 ```
 
 Listen

--- a/id-id/asciidoc-id.html.markdown
+++ b/id-id/asciidoc-id.html.markdown
@@ -84,10 +84,6 @@ Judul bagian
 
 ===== Level 4 <h5>
 
-====== Level 5 <h6>
-
-======= Level 6 <h7>
-
 ```
 
 Daftar

--- a/pt-br/asciidoc-pt.html.markdown
+++ b/pt-br/asciidoc-pt.html.markdown
@@ -87,10 +87,6 @@ Título de seções
 
 ===== Nível 4 <h5>
 
-====== Nível 5 <h6>
-
-======= Nível 6  <h7>
-
 ```
 
 Listas


### PR DESCRIPTION
AsciiDoc section levels

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
