### PR TITLE
[zfs/en] Fix for unordered lists not rendering properly

### DIFF
--- a/zfs.html.markdown
+++ b/zfs.html.markdown
@@ -149,6 +149,7 @@ $ zpool destroy test
 ### Datasets
 
 Actions:
+
 * Create
 * List
 * Rename
@@ -269,6 +270,7 @@ ZFS snapshots are one of the things about zfs that are a really big deal
 * They are easy to automate.
 
 Actions:
+
 * Create
 * Delete
 * Rename


### PR DESCRIPTION
Really simple markdown fix for #2313, where unordered lists require a blank line to precede bullet items.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
