### PR TITLE
[chapel/en] Chapel version update, mixed quotes

### DIFF
--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -188,7 +188,7 @@ if 10 < 100 then
 if -1 < 1 then
   writeln("Continuing to believe reality");
 else
-  writeln("Send mathematician, something's wrong");
+  writeln("Send mathematician, something is wrong");
 
 // You can use parentheses if you prefer.
 if (10 > 100) {
@@ -213,7 +213,7 @@ if a % 3 == 0 {
 var maximum = if thisInt < thatInt then thatInt else thisInt;
 
 // select statements are much like switch statements in other languages.
-// However, select statements don't cascade like in C or Java.
+// However, select statements do not cascade like in C or Java.
 var inputOption = "anOption";
 select inputOption {
   when "anOption" do writeln("Chose 'anOption'");
@@ -223,7 +223,7 @@ select inputOption {
   }
   otherwise {
     writeln("Any other Input");
-    writeln("the otherwise case doesn't need a do if the body is one line");
+    writeln("the otherwise case does not need a do if the body is one line");
   }
 }
 
@@ -282,7 +282,7 @@ var range2to10by2: range(stridable=true) = 2..10 by 2; // 2, 4, 6, 8, 10
 var reverse2to10by2 = 2..10 by -2; // 10, 8, 6, 4, 2
 
 var trapRange = 10..1 by -1; // Do not be fooled, this is still an empty range
-writeln("Size of range '", trapRange, "' = ", trapRange.length);
+writeln("Size of range ", trapRange, " = ", trapRange.length);
 
 // Note: range(boundedType= ...) and range(stridable= ...) are only
 // necessary if we explicitly type the variable.
@@ -425,7 +425,7 @@ var thisPlusThat = thisArray + thatArray;
 writeln(thisPlusThat);
 
 // Moving on, arrays and loops can also be expressions, where the loop
-// body's expression is the result of each iteration.
+// body expression is the result of each iteration.
 var arrayFromLoop = for i in 1..10 do i;
 writeln(arrayFromLoop);
 
@@ -1141,7 +1141,7 @@ to see if more topics have been added or more tutorials created.
 Your input, questions, and discoveries are important to the developers!
 -----------------------------------------------------------------------
 
-The Chapel language is still in-development (version 1.15.0), so there are
+The Chapel language is still in-development (version 1.16.0), so there are
 occasional hiccups with performance and language features. The more information
 you give the Chapel development team about issues you encounter or features you
 would like to see, the better the language becomes. Feel free to email the team
@@ -1158,8 +1158,8 @@ Chapel can be built and installed on your average 'nix machine (and cygwin).
 [Download the latest release version](https://github.com/chapel-lang/chapel/releases/)
 and it's as easy as
 
- 1. `tar -xvf chapel-1.15.0.tar.gz`
- 2. `cd chapel-1.15.0`
+ 1. `tar -xvf chapel-1.16.0.tar.gz`
+ 2. `cd chapel-1.16.0`
  3. `source util/setchplenv.bash # or .sh or .csh or .fish`
  4. `make`
  5. `make check # optional`


### PR DESCRIPTION
+ Chapel is now version 1.16.0
+ The syntax highlighter does *not* like single quotes `'` mixed with double quotes `"`. I have removed what appear to be the worst offenders.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
