### PR TITLE
[clojure-macros/en] Fix typo

### DIFF
--- a/clojure-macros.html.markdown
+++ b/clojure-macros.html.markdown
@@ -131,7 +131,7 @@ You'll want to be familiar with Clojure. Make sure you understand everything in
 
 ; However, we'll need to make it a macro if we want it to be run at compile time
 (defmacro inline-2 [form]
-  (inline-2-helper form)))
+  (inline-2-helper form))
 
 (macroexpand '(inline-2 (1 + (3 / 2) - (1 / 2) + 1)))
 ; -> (+ (- (+ 1 (/ 3 2)) (/ 1 2)) 1)


### PR DESCRIPTION
Remove unnecessary closing parenthesis from inline-2 macro.

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
