### PR TITLE
[dynamic-programming/en] add backticks to escape markdown formatting characters

### DIFF
--- a/dynamic-programming.html.markdown
+++ b/dynamic-programming.html.markdown
@@ -26,7 +26,7 @@ The Longest Increasing Subsequence problem is to find the longest increasing sub
 First of all we have to find the value of the longest subsequences(LSi) at every index i with last element of sequence being ai. Then largest LSi would be the longest subsequence in the given sequence. To begin LSi is assigned to be one since ai is element of the sequence(Last element). Then for all `j` such that `j<i` and `aj<ai`, we find Largest LSj and add it to LSi. Then algorithm take *O(n2)* time.
 
 Pseudo-code for finding the length of the longest increasing subsequence:
-This algorithms complexity could be reduced by using better data structure rather than array. Storing predecessor array and variable like largest_sequences_so_far and its index would save a lot time.
+This algorithms complexity could be reduced by using better data structure rather than array. Storing predecessor array and variable like `largest_sequences_so_far` and its index would save a lot time.
 
 Similar concept could be applied in finding longest path in Directed acyclic graph.
 


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!


The issue this fixes can be seen at the live [Dynamic Programming page](https://learnxinyminutes.com/docs/dynamic-programming/), the unescaped underscores are picked up as markdown formatting in the word `largest_sequences_so_far`, making it appear as largest _sequences_ so_far