### PR TITLE
[html/it] add missing lang declaration to html-it

### DIFF
--- a/it-it/html-it.html.markdown
+++ b/it-it/html-it.html.markdown
@@ -5,6 +5,7 @@ contributors:
     - ["Christophe THOMAS", "https://github.com/WinChris"]
 translators:
     - ["Ale46", "http://github.com/Ale46/"]
+lang: it-it
 ---
 
 HTML sta per HyperText Markup Language (linguaggio a marcatori per ipertesti).


### PR DESCRIPTION
The missing declaration caused the Italian version show up as a duplicate HTML article on the live site, becoming the parent of every further translation. Same basic issue as [PR#2573](https://github.com/adambard/learnxinyminutes-docs/issues/2573).

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
