### PR TITLE
[edn] Fix incorrect format for EDN symbols

### DIFF
--- a/edn.html.markdown
+++ b/edn.html.markdown
@@ -44,13 +44,13 @@ false
 :cheese
 :olives
 
-; Symbols are used to represent identifiers. They start with #.
+; Symbols are used to represent identifiers. 
 ; You can namespace symbols by using /. Whatever precedes / is
-; the namespace of the name.
-#spoon
-#kitchen/spoon ; not the same as #spoon
-#kitchen/fork
-#github/fork   ; you can't eat with this
+; the namespace of the symbol.
+spoon
+kitchen/spoon ; not the same as spoon
+kitchen/fork
+github/fork   ; you can't eat with this
 
 ; Integers and floats
 42


### PR DESCRIPTION
EDN symbols do not start with a # character

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
  - [x] Yes, I have double-checked quotes and field names!

here's the relevant spec on the canonical edn github readme: https://github.com/edn-format/edn#symbols