### PR TITLE
[make/en || de] Fix for wrong/mixed parenthesis usage.

### DIFF
--- a/de-de/make-de.html.markdown
+++ b/de-de/make-de.html.markdown
@@ -2,6 +2,7 @@
 language: make
 contributors:
     - ["Robert Steed", "https://github.com/robochat"]
+    - ["Stephan Fuhrmann", "https://github.com/sfuhrm"]
 translators:
   - ["Martin Schimandl", "https://github.com/Git-Jiro"]
 filename: Makefile-de
@@ -58,7 +59,7 @@ file2.txt file3.txt: file0.txt file1.txt
 	touch file3.txt
 
 # Make wird sich beschweren wenn es mehrere Rezepte für die gleiche Regel gibt.
-# Leere Rezepte zählen nicht und können dazu verwendet werden weitere 
+# Leere Rezepte zählen nicht und können dazu verwendet werden weitere
 # Voraussetzungen hinzuzufügen.
 
 #-----------------------------------------------------------------------
@@ -182,9 +183,9 @@ echo: name2 = Sara # Wahr innerhalb der passenden Regel und auch innerhalb
 # Ein paar Variablen die von Make automatisch definiert werden.
 echo_inbuilt:
 	echo $(CC)
-	echo ${CXX)}
+	echo ${CXX}
 	echo $(FC)
-	echo ${CFLAGS)}
+	echo ${CFLAGS}
 	echo $(CPPFLAGS)
 	echo ${CXXFLAGS}
 	echo $(LDFLAGS)

--- a/make.html.markdown
+++ b/make.html.markdown
@@ -2,6 +2,7 @@
 language: make
 contributors:
     - ["Robert Steed", "https://github.com/robochat"]
+    - ["Stephan Fuhrmann", "https://github.com/sfuhrm"]
 filename: Makefile
 ---
 
@@ -11,7 +12,7 @@ target to the most recent version of the source. Famously written over a
 weekend by Stuart Feldman in 1976, it is still widely used (particularly
 on Unix and Linux) despite many competitors and criticisms.
 
-There are many varieties of make in existence, however this article 
+There are many varieties of make in existence, however this article
 assumes that we are using GNU make which is the standard on Linux.
 
 ```make
@@ -168,9 +169,9 @@ echo: name2 = Sara # True within the matching rule
 # Some variables defined automatically by make.
 echo_inbuilt:
 	echo $(CC)
-	echo ${CXX)}
+	echo ${CXX}
 	echo $(FC)
-	echo ${CFLAGS)}
+	echo ${CFLAGS}
 	echo $(CPPFLAGS)
 	echo ${CXXFLAGS}
 	echo $(LDFLAGS)


### PR DESCRIPTION
Fix for wrong use of parenthesis: You can't mix curly and plain braces in Make:

    $ make test
    makefile:2: *** Nicht abgeschlossene Variablenreferenz.  Schluss.
    $ 


Please note that the files had 99% `\r\n` line endings, so I also corrected the missing `\r\n` endings for lines that were added with `\n` only by other authors.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
