### PR TITLE
[elm] Update code to access tuples

### DIFF
--- a/cs-cz/elm.html.markdown
+++ b/cs-cz/elm.html.markdown
@@ -75,8 +75,8 @@ List.head [] -- Nothing
 
 -- K získání hodnot z dvojice použijte funkce first a second.
 -- (Toto je pouze zkratka. Brzy si ukážeme, jak na to "správně".)
-fst ("elm", 42) -- "elm"
-snd ("elm", 42) -- 42
+Tuple.first ("elm", 42) -- "elm"
+Tuple.second ("elm", 42) -- 42
 
 -- Prázná n-tice, neboli "unit", se občas používá jako zástupný symbol.
 -- Je to jediná hodnota svého typu, který se také nazývá "Unit".

--- a/elm.html.markdown
+++ b/elm.html.markdown
@@ -72,8 +72,8 @@ List.head [] -- Nothing
 
 -- Access the elements of a pair with the first and second functions.
 -- (This is a shortcut; we'll come to the "real way" in a bit.)
-fst ("elm", 42) -- "elm"
-snd ("elm", 42) -- 42
+Tuple.first ("elm", 42) -- "elm"
+Tuple.second ("elm", 42) -- 42
 
 -- The empty tuple, or "unit", is sometimes used as a placeholder.
 -- It is the only value of its type, also called "Unit".

--- a/pt-br/elm-pt.html.markdown
+++ b/pt-br/elm-pt.html.markdown
@@ -76,8 +76,8 @@ List.head [] -- Nothing
 
 -- Acesse os elementos de um par com as funções first e second.
 -- (Este é um atalho; nós iremos para o "caminho real" em breve.)
-fst ("elm", 42) -- "elm"
-snd ("elm", 42) -- 42
+Tuple.first ("elm", 42) -- "elm"
+Tuple.second ("elm", 42) -- 42
 
 -- Uma tupla vazia ou "unidade" às vezes é utilizada como um placeholder.
 -- É o único valor de seu tipo, também chamado de "Unit".


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` // did it for all existing languages
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)

Elm has no longer functions `fst` and `snd` to access tuple values and they're no longer part of the Basics. Instead `Tuple` functions `first` and `second` have to be used. The change is documented in the [upgrade-docs/0.18.md](https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#renamed-functions-in-core)

Change made in en, cs-cz and pt-br (all currently existing elm files).