### PR TITLE
[nim/en] Fix the multiline Nim comment (#3031)

### DIFF
--- a/nim.html.markdown
+++ b/nim.html.markdown
@@ -15,15 +15,9 @@ Nim is efficient, expressive, and elegant.
 # Single-line comments start with a #
 
 #[
-  Multi-line comments begin with a #[
-  ... and end with ]#
-
-They don't care about indentation
-
-  #[
-  and they can be nested
-  ]#
-
+  This is a multiline comment.
+  In Nim, multiline comments can be nested, beginning with #[
+  ... and ending with ]#
 ]#
 
 discard """


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)

This pull request:

- Fixes the multiline Nim comment affecting the rest of the markdown preview. (#3031)
- Removes the commentary on indentation. Since these guides target intermediate to experienced programmers, they should already know that comments can be formatted however one pleases.
- Clarifies that although Nim supports nested comments, not all programming languages do.