### PR TITLE
[go/en] Small typo

### DIFF
--- a/go.html.markdown
+++ b/go.html.markdown
@@ -180,7 +180,7 @@ func learnFlowControl() {
 	if true {
 		fmt.Println("told ya")
 	}
-	// Formatting is standardized by the command line command "go fmt."
+	// Formatting is standardized by the command line command "go fmt".
 	if false {
 		// Pout.
 	} else {


### PR DESCRIPTION
Small typo in command line command

- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] Yes, I have double-checked quotes and field names!
