### PR TITLE
[pythonstatcomp/en] IPython notebooks are Jupyter notebooks now

### DIFF
--- a/pythonstatcomp.html.markdown
+++ b/pythonstatcomp.html.markdown
@@ -13,10 +13,11 @@ This is a tutorial on how to do some typical statistical programming tasks using
 
 # 0. Getting set up ====
 
-""" Get set up with IPython and pip install the following: numpy, scipy, pandas,
+""" To get started, pip install the following: jupyter, numpy, scipy, pandas,
     matplotlib, seaborn, requests.
-        Make sure to do this tutorial in the IPython notebook so that you get
-    the inline plots and easy documentation lookup.
+        Make sure to do this tutorial in a Jupyter notebook so that you get
+    the inline plots and easy documentation lookup. The shell command to open 
+    one is simply `jupyter notebook`, then click New -> Python.
 """
 
 # 1. Data acquisition ====


### PR DESCRIPTION
IPython still exists, but the notebooks have been spun off into their own project called Jupyter. This file change:
* updates the pip install queue so that Jupyter gets installed
* removes the vague "get set up with IPython" (pip will install IPython with Jupyter), and
* replaced the suggestion to work in "the IPython notebook" with "a Jupyter notebook".

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
