### PR TITLE
[toml/en] add clarifying example and text for date/time offsets

### DIFF
--- a/toml.html.markdown
+++ b/toml.html.markdown
@@ -102,9 +102,10 @@ boolMustBeLowercase = true
 # Datetime #
 ############
 
-date1 = 1979-05-27T07:32:00Z # follows the RFC 3339 spec
-date2 = 1979-05-27T07:32:00 # without offset
-date3 = 1979-05-27 # without offset nor time
+date1 = 1979-05-27T07:32:00Z # UTC time, following RFC 3339/ISO 8601 spec
+date2 = 1979-05-26T15:32:00+08:00 # with RFC 3339/ISO 8601 offset
+date3 = 1979-05-27T07:32:00 # without offset
+date4 = 1979-05-27 # without offset or time
 
 ####################
 # COLLECTION TYPES #


### PR DESCRIPTION
- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
- [X] Yes, I have double-checked quotes and field names!

Enhances the TOML documnetation by adding a clarifying example to the `Datetime` section using an RFC 3339/ISO 8601 offset, and clarifies and grammaticalizes the surrounding text.