### PR TITLE
[latex/en-en] Fix paragraph separation, inter-word space, add microtype package

### DIFF
--- a/latex.html.markdown
+++ b/latex.html.markdown
@@ -6,6 +6,7 @@ contributors:
     - ["Sricharan Chiruvolu", "http://sricharan.xyz"]
     - ["Ramanan Balakrishnan", "https://github.com/ramananbalakrishnan"]
     - ["Svetlana Golubeva", "https://attillax.github.io/"]
+    - ["Oliver Kopp", "http://orcid.org/0000-0001-6962-4290"]
 filename: learn-latex.tex
 ---
 
@@ -38,7 +39,7 @@ filename: learn-latex.tex
 \author{Chaitanya Krishna Ande, Colton Kohnke, Sricharan Chiruvolu \& \\
 Svetlana Golubeva}
 \date{\today}
-\title{Learn \LaTeX \hspace{1pt} in Y Minutes!}
+\title{Learn \LaTeX{} in Y Minutes!}
 
 % Now we're ready to begin the document
 % Everything before this line is called "The Preamble"
@@ -61,7 +62,7 @@ Svetlana Golubeva}
 % but before the main sections of the body.
 % This command is available in the document classes article and report.
 \begin{abstract}
- \LaTeX \hspace{1pt} documentation written as \LaTeX! How novel and totally not
+ \LaTeX{} documentation written as \LaTeX! How novel and totally not
  my idea!
 \end{abstract}
 
@@ -74,7 +75,7 @@ Hello, my name is Colton and together we're going to explore \LaTeX!
 This is the text for another section. I think it needs a subsection.
 
 \subsection{This is a subsection} % Subsections are also intuitive.
-I think we need another one
+I think we need another one.
 
 \subsubsection{Pythagoras}
 Much better now.
@@ -87,10 +88,15 @@ However not all sections have to be numbered!
 
 \section{Some Text notes}
 %\section{Spacing} % Need to add more information about space intervals
-\LaTeX \hspace{1pt} is generally pretty good about placing text where it should
+\LaTeX{} is generally pretty good about placing text where it should
 go. If
-a line \\ needs \\ to \\ break \\ you add \textbackslash\textbackslash
-\hspace{1pt} to the source code. \\
+a line \\ needs \\ to \\ break \\ you add \textbackslash\textbackslash{}
+to the source code.
+
+Separate paragraphs by empty lines.
+
+You need to add a dot after abbreviations (if not followed by a comma), because otherwise the spacing after the dot is too large:
+E.g., i.e., etc.\ are are such abbreviations.
 
 \section{Lists}
 Lists are one of the easiest things to create in \LaTeX! I need to go shopping
@@ -109,15 +115,15 @@ tomorrow, so let's make a grocery list.
 
 \section{Math}
 
-One of the primary uses for \LaTeX \hspace{1pt} is to produce academic articles
+One of the primary uses for \LaTeX{} is to produce academic articles
 or technical papers. Usually in the realm of math and science. As such,
-we need to be able to add special symbols to our paper! \\
+we need to be able to add special symbols to our paper!
 
 Math has many symbols, far beyond what you can find on a keyboard;
-Set and relation symbols, arrows, operators, and Greek letters to name a few.\\
+Set and relation symbols, arrows, operators, and Greek letters to name a few.
 
 Sets and relations play a vital role in many mathematical research papers.
-Here's how you state all x that belong to X, $\forall$ x $\in$ X. \\
+Here's how you state all x that belong to X, $\forall$ x $\in$ X.
 % Notice how I needed to add $ signs before and after the symbols. This is
 % because when writing, we are in text-mode.
 % However, the math symbols only exist in math-mode.
@@ -128,16 +134,16 @@ Here's how you state all x that belong to X, $\forall$ x $\in$ X. \\
 \[a^2 + b^2 = c^2 \]
 
 My favorite Greek letter is $\xi$. I also like $\beta$, $\gamma$ and $\sigma$.
-I haven't found a Greek letter yet that \LaTeX \hspace{1pt} doesn't know
-about! \\
+I haven't found a Greek letter yet that \LaTeX{} doesn't know
+about!
 
 Operators are essential parts of a mathematical document:
 trigonometric functions ($\sin$, $\cos$, $\tan$),
 logarithms and exponentials ($\log$, $\exp$),
-limits ($\lim$), etc.
+limits ($\lim$), etc.\ 
 have per-defined LaTeX commands.
 Let's write an equation to see how it's done:
-$\cos(2\theta) = \cos^{2}(\theta) - \sin^{2}(\theta)$ \\
+$\cos(2\theta) = \cos^{2}(\theta) - \sin^{2}(\theta)$
 
 Fractions (Numerator-denominators) can be written in these forms:
 
@@ -146,7 +152,7 @@ $$ ^{10}/_{7} $$
 
 % Relatively complex fractions can be written as
 % \frac{numerator}{denominator}
-$$ \frac{n!}{k!(n - k)!} $$ \\
+$$ \frac{n!}{k!(n - k)!} $$
 
 We can also insert equations in an ``equation environment''.
 
@@ -174,7 +180,7 @@ Summations and Integrals are written with sum and int commands:
 
 \section{Figures}
 
-Let's insert a Figure. Figure placement can get a little tricky.
+Let's insert a figure. Figure placement can get a little tricky.
 I definitely have to lookup the placement options each time.
 
 \begin{figure}[H] % H here denoted the placement option.
@@ -201,9 +207,9 @@ We can also insert Tables in the same way as figures.
   \end{tabular}
 \end{table}
 
-\section{Getting \LaTeX \hspace{1pt} to not compile something (i.e. Source Code)}
-Let's say we want to include some code into our \LaTeX \hspace{1pt} document,
-we would then need \LaTeX \hspace{1pt} to not try and interpret that text and
+\section{Getting \LaTeX{} to not compile something (i.e.\ Source Code)}
+Let's say we want to include some code into our \LaTeX{} document,
+we would then need \LaTeX{} to not try and interpret that text and
 instead just print it to the document. We do this with a verbatim
 environment.
 
@@ -218,9 +224,10 @@ environment.
 \section{Compiling}
 
 By now you're probably wondering how to compile this fabulous document
-and look at the glorious glory that is a \LaTeX \hspace{1pt} pdf.
-(yes, this document actually does compile). \\
-Getting to the final document using \LaTeX \hspace{1pt} consists of the following
+and look at the glorious glory that is a \LaTeX{} pdf.
+(yes, this document actually does compile).
+
+Getting to the final document using \LaTeX{} consists of the following
 steps:
   \begin{enumerate}
     \item Write the document in plain text (the ``source code'').
@@ -231,7 +238,7 @@ steps:
      \end{verbatim}
   \end{enumerate}
 
-A number of \LaTeX \hspace{1pt}editors combine both Step 1 and Step 2 in the
+A number of \LaTeX{} editors combine both Step 1 and Step 2 in the
 same piece of software. So, you get to see Step 1, but not Step 2 completely.
 Step 2 is still happening behind the scenes\footnote{In cases, where you use
 references (like Eqn.~\ref{eq:pythagoras}), you may need to run Step 2
@@ -267,9 +274,8 @@ That's all for now!
 \begin{thebibliography}{1}
   % similar to other lists, the \bibitem command can be used to list items
   % each entry can then be cited directly in the body of the text
-  \bibitem{latexwiki} The amazing \LaTeX \hspace{1pt} wikibook: {\em
-https://en.wikibooks.org/wiki/LaTeX}
-  \bibitem{latextutorial} An actual tutorial: {\em http://www.latex-tutorial.com}
+  \bibitem{latexwiki} The amazing \LaTeX{} wikibook: \emph{https://en.wikibooks.org/wiki/LaTeX}
+  \bibitem{latextutorial} An actual tutorial: \emph{http://www.latex-tutorial.com}
 \end{thebibliography}
 
 % end the document


### PR DESCRIPTION
This fixes basic LaTeX mistakes:

- paragraphs are separated by empty lines, never by `\\`
- In case a LaTeX command is invoked without parameters, the correct syntax is `\command{}` and not `\command \hspace{1pt}`, because the space between words is not always 1pt, but can vary
- fix spacing after "etc." (huge mistake often made)

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
