### PR TITLE
[javascript/en-us] Delete broken link to Eloquent Javascript - The Annotated Version

### DIFF
--- a/javascript.html.markdown
+++ b/javascript.html.markdown
@@ -600,10 +600,6 @@ of the language.
 [Eloquent Javascript][8] by Marijn Haverbeke is an excellent JS book/ebook with
 attached terminal
 
-[Eloquent Javascript - The Annotated Version][9] by Gordon Zhu is also a great
-derivative of Eloquent Javascript with extra explanations and clarifications for
-some of the more complicated examples.
-
 [Javascript: The Right Way][10] is a guide intended to introduce new developers
 to JavaScript and help experienced developers learn more about its best practices.
 
@@ -624,6 +620,5 @@ Mozilla Developer Network.
 [6]: http://www.amazon.com/gp/product/0596805527/
 [7]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript
 [8]: http://eloquentjavascript.net/
-[9]: http://watchandcode.com/courses/eloquent-javascript-the-annotated-version
 [10]: http://jstherightway.org/
 [11]: https://javascript.info/


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!

The annoted version by Gordon Zhu, of the book "Eloquent Javascript" by Marijn Haverbeke, is not available anymore. Therefore I deleted the link to it.

I suggest to insert a new link pointing to the new material (https://watchandcode.com/courses/practical-javascript) on Javascript by Gordon Zhu, since I think it's very valuable content. I can make it myself, with another pull request, by I'll wait for the administrator permission.
