### PR TITLE
missing $ on line 77 - $Length

### DIFF
--- a/bash.html.markdown
+++ b/bash.html.markdown
@@ -74,7 +74,7 @@ echo ${Variable/Some/A} # => A string
 
 # Substring from a variable
 Length=7
-echo ${Variable:0:Length} # => Some st
+echo ${Variable:0:$Length} # => Some st
 # This will return only the first 7 characters of the value
 
 # Default value for variable


### PR DESCRIPTION
Maybe just a zsh quirk? 

➜  ~ echo ${Variable:0:Length} 
zsh: unrecognized modifier

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
