### PR TITLE
[python3/en] added example for f-string

### DIFF
--- a/python3.html.markdown
+++ b/python3.html.markdown
@@ -138,6 +138,10 @@ len("This is a string")  # => 16
 # still use the old style of formatting:
 "%s can be %s the %s way" % ("Strings", "interpolated", "old")  # => "Strings can be interpolated the old way"
 
+# You can also format using f-strings or formatted string literals
+name = "Reiko"
+f"She said her name is {name}." # => "She said her name is Reiko"
+
 
 # None is an object
 None  # => None


### PR DESCRIPTION
Literal string interpolation is new in python 3.6 [pep-0498](https://www.python.org/dev/peps/pep-0498/)

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
