### PR TITLE
[lua/en] Added comment on ternary wonkiness

### DIFF
--- a/lua.html.markdown
+++ b/lua.html.markdown
@@ -62,9 +62,10 @@ if not aBoolValue then print('twas false') end
 -- in C/js:
 ans = aBoolValue and 'yes' or 'no'  --> 'no'
 
--- BEWARE: this only acts as a ternary value returned when the condition is true is not `false` or Nil
-ans1 = aBoolValue and false or true --> true
-ans2 = aBoolValue and true or false --> true
+-- BEWARE: this only acts as a ternary if the value returned when the condition 
+-- evaluates to true is not `false` or Nil
+iAmNotFalse = (not aBoolValue) and false or true --> true
+iAmAlsoNotFalse = (not aBoolValue) and true or false --> true
 
 karlSum = 0
 for i = 1, 100 do  -- The range includes both ends.

--- a/lua.html.markdown
+++ b/lua.html.markdown
@@ -62,6 +62,10 @@ if not aBoolValue then print('twas false') end
 -- in C/js:
 ans = aBoolValue and 'yes' or 'no'  --> 'no'
 
+-- BEWARE: this only acts as a ternary value returned when the condition is true is not `false` or Nil
+ans1 = aBoolValue and false or true --> true
+ans2 = aBoolValue and true or false --> true
+
 karlSum = 0
 for i = 1, 100 do  -- The range includes both ends.
   karlSum = karlSum + i


### PR DESCRIPTION
Ternaries in Lua have a quirk where they only behave like C++/JS/PHP ternaries if the value when the condition evaluates to true is also truthy i.e not Nil or False. If the value is falsey, the other value is returned i.e. `(1 == 1) and false or true` will return `true` instead of `false`

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
