### PR TITLE
[bash/en] clarify quoted delimiter for heredocs (fixes #3061)

### DIFF
--- a/bash.html.markdown
+++ b/bash.html.markdown
@@ -256,6 +256,7 @@ print("#stderr", file=sys.stderr)
 for line in sys.stdin:
     print(line, file=sys.stdout)
 EOF
+# Variables will be expanded if the first "EOF" is not quoted
 
 # Run the hello.py Python script with various stdin, stdout, and 
 # stderr redirections:


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
