### PR TITLE
[go/it-it] Fix `defer` wording, as shown in ff06f9cf993c79b843008a641…

### DIFF
--- a/it-it/go-it.html.markdown
+++ b/it-it/go-it.html.markdown
@@ -270,12 +270,13 @@ func fabbricaDiFrasi(miaStringa string) func(prima, dopo string) string {
 }
 
 func imparaDefer() (ok bool) {
-    // Le istruzioni dette "deferred" (rinviate) sono eseguite
-    // appena prima che la funzione abbia termine.
+	// La parola chiave "defer" inserisce una funzione in una lista.
+	// La lista contenente tutte le chiamate a funzione viene eseguita DOPO
+	// il return finale della funzione che le circonda.
 	defer fmt.Println("le istruzioni 'deferred' sono eseguite in ordine inverso (LIFO).")
 	defer fmt.Println("\nQuesta riga viene stampata per prima perché")
     // defer viene usato di solito per chiudere un file, così la funzione che
-    // chiude il file viene messa vicino a quella che lo apre.
+    // chiude il file, preceduta da "defer", viene messa vicino a quella che lo apre.
 	return true
 }
 


### PR DESCRIPTION
…abb92e183cff285

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
