### PR TITLE
[ruby/en] Fix typo for ruby

### DIFF
--- a/ruby.html.markdown
+++ b/ruby.html.markdown
@@ -377,7 +377,7 @@ sum sum(3, 4), 5 #=> 12
 
 # yield
 # All methods have an implicit, optional block parameter.
-# Tt can be called with the 'yield' keyword.
+# It can be called with the 'yield' keyword.
 def surround
   puts '{'
   yield


### PR DESCRIPTION
This fixes a small typo in the ruby documentation ("Tt"-->"It").

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
