### PR TITLE
[racket/en] Fix section numbering

### DIFF
--- a/racket.html.markdown
+++ b/racket.html.markdown
@@ -249,7 +249,7 @@ m ; => '#hash((b . 2) (a . 1) (c . 3))  <-- no `d'
 (hash-remove m 'a) ; => '#hash((b . 2) (c . 3))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 3. Functions
+;; 4. Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Use `lambda' to create functions.
@@ -319,7 +319,7 @@ m ; => '#hash((b . 2) (a . 1) (c . 3))  <-- no `d'
                                          ; => "Hi Finn, 6 extra args"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 4. Equality
+;; 5. Equality
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; for numbers use `='
@@ -369,7 +369,7 @@ m ; => '#hash((b . 2) (a . 1) (c . 3))  <-- no `d'
 (equal? (list 3) (list 3))                                       ; => #t
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 5. Control Flow
+;; 6. Control Flow
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;; Conditionals
@@ -505,7 +505,7 @@ m ; => '#hash((b . 2) (a . 1) (c . 3))  <-- no `d'
   (+ 1 (raise 2))) ; => 2
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 6. Mutation
+;; 7. Mutation
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Use `set!' to assign a new value to an existing variable
@@ -541,7 +541,7 @@ vec ; => #(1 2 3 4)
 (hash-remove! m3 'a)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 7. Modules
+;; 8. Modules
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Modules let you organize code into multiple files and reusable
@@ -568,7 +568,7 @@ vec ; => #(1 2 3 4)
 ; (show "~a" 1 #\A) ; => error, `show' was not exported
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 8. Classes and Objects
+;; 9. Classes and Objects
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Create a class fish% (-% is idiomatic for class bindings)
@@ -609,7 +609,7 @@ vec ; => #(1 2 3 4)
 (send (new (add-color fish%) [size 10] [color 'red]) get-color)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 9. Macros
+;; 10. Macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Macros let you extend the syntax of the language
@@ -651,7 +651,7 @@ vec ; => #(1 2 3 4)
 ;; it, the compiler will get in an infinite loop
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 10. Contracts
+;; 11. Contracts
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Contracts impose constraints on values exported from modules
@@ -678,7 +678,7 @@ vec ; => #(1 2 3 4)
 ;; more details....
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; 11. Input & output
+;; 12. Input & output
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Racket has this concept of "port", which is very similar to file


### PR DESCRIPTION
This is really a minor issue.
Index number for the `Functions` sections is numbered `3.` -- just like the `Structs and Collections` section before it.
This fixes section numbering for `Functions` and all subsequent sections.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
