### PR TITLE
[ocaml/en] Fix typo

### DIFF
--- a/ocaml.html.markdown
+++ b/ocaml.html.markdown
@@ -161,7 +161,7 @@ let my_lambda = fun x -> x * x ;;
 
 (*** Operators ***)
 
-(* There is little distintion between operators and functions.
+(* There is little distinction between operators and functions.
    Every operator can be called as a function. *)
 
 (+) 3 4  (* Same as 3 + 4 *)


### PR DESCRIPTION
Just fixing a typo.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)