### PR TITLE
[Markdown/fr] Fix missing 'r' in the word "centré"

### DIFF
--- a/fr-fr/markdown-fr.html.markdown
+++ b/fr-fr/markdown-fr.html.markdown
@@ -350,7 +350,7 @@ ne sont pas tres agréable d'utilisation. Mais si vous en avez besoin :
 ```md
 | Col1 | Col2 | Col3 |
 | :----------- | :------: | ------------: |
-| Alignement Gauche | Centé | Alignement Droite |
+| Alignement Gauche | Centré | Alignement Droite |
 | bla | bla | bla |
 ```
 


### PR DESCRIPTION
Line 353 the word `centré` was write `centé`

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Yes, I have double-checked quotes and field names!
