### PR TITLE
[julia/en] tweak order of string functions / print functions

### DIFF
--- a/julia.html.markdown
+++ b/julia.html.markdown
@@ -93,21 +93,22 @@ ascii("This is a string")[1]
 # Julia indexes from 1
 # Otherwise, iterating over strings is recommended (map, for loops, etc).
 
+# String can be compared lexicographically
+"good" > "bye" # => true
+"good" == "good" # => true
+"1 + 2 = 3" == "1 + 2 = $(1 + 2)" # => true
+
 # $ can be used for string interpolation:
 "2 + 2 = $(2 + 2)" # => "2 + 2 = 4"
 # You can put any Julia expression inside the parentheses.
+
+# Printing is easy
+println("I'm Julia. Nice to meet you!") # => I'm Julia. Nice to meet you!
 
 # Another way to format strings is the printf macro from the stdlib Printf.
 using Printf
 @printf "%d is less than %f\n" 4.5 5.3  # => 5 is less than 5.300000
 
-# Printing is easy
-println("I'm Julia. Nice to meet you!") # => I'm Julia. Nice to meet you!
-
-# String can be compared lexicographically
-"good" > "bye" # => true
-"good" == "good" # => true
-"1 + 2 = 3" == "1 + 2 = $(1 + 2)" # => true
 
 ####################################################
 ## 2. Variables and Collections


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!


This is a better order I think.
Show the normal way to print before showing the use of the `Printf` stdlib.
Also finish doing string examples before moving on to printing 