### PR TITLE
[latex/en] Fix comment on using \ after abbreviations

### DIFF
--- a/latex.html.markdown
+++ b/latex.html.markdown
@@ -95,7 +95,7 @@ to the source code.
 
 Separate paragraphs by empty lines.
 
-You need to add a dot after abbreviations (if not followed by a comma), because otherwise the spacing after the dot is too large:
+You need to add a backslash after abbreviations (if not followed by a comma), because otherwise the spacing after the dot is too large:
 E.g., i.e., etc.\ are are such abbreviations.
 
 \section{Lists}


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
