### PR TITLE
[python/all] Type correction for the output of math.sqrt()

### DIFF
--- a/cs-cz/python3.html.markdown
+++ b/cs-cz/python3.html.markdown
@@ -572,7 +572,7 @@ Clovek.odkaslej_si()  # => "*ehm*"
 
 # Lze importovat moduly
 import math
-print(math.sqrt(16.0))  # => 4
+print(math.sqrt(16.0))  # => 4.0
 
 # Lze také importovat pouze vybrané funkce z modulu
 from math import ceil, floor

--- a/de-de/python-de.html.markdown
+++ b/de-de/python-de.html.markdown
@@ -442,7 +442,7 @@ Human.grunt() #=> "*grunt*"
 
 # Wir können Module importieren
 import math
-print math.sqrt(16) #=> 4
+print math.sqrt(16) #=> 4.0
 
 # Wir können auch nur spezielle Funktionen eines Moduls importieren
 from math import ceil, floor

--- a/de-de/python3-de.html.markdown
+++ b/de-de/python3-de.html.markdown
@@ -555,7 +555,7 @@ Human.grunt() #=> "*grunt*"
 
 # Wir können Module importieren
 import math
-print(math.sqrt(16)) #=> 4
+print(math.sqrt(16)) #=> 4.0
 
 # Wir können auch nur spezielle Funktionen eines Moduls importieren
 from math import ceil, floor

--- a/es-es/python-es.html.markdown
+++ b/es-es/python-es.html.markdown
@@ -467,7 +467,7 @@ Humano.roncar() #=> "*roncar*"
 
 # Puedes importar módulos
 import math
-print math.sqrt(16) #=> 4
+print math.sqrt(16) #=> 4.0
 
 # Puedes obtener funciones específicas desde un módulo
 from math import ceil, floor

--- a/fr-fr/python-fr.html.markdown
+++ b/fr-fr/python-fr.html.markdown
@@ -444,7 +444,7 @@ Human.grunt() #=> "*grunt*"
 
 # On peut importer des modules
 import math
-print math.sqrt(16) #=> 4
+print math.sqrt(16) #=> 4.0
 
 # Et récupérer des fonctions spécifiques d'un module
 from math import ceil, floor

--- a/hu-hu/python-hu.html.markdown
+++ b/hu-hu/python-hu.html.markdown
@@ -656,7 +656,7 @@ i.age  # => AttributeError hibát dob
 # Modulokat így lehet importálni
 import math
 
-print math.sqrt(16)  # => 4
+print math.sqrt(16)  # => 4.0
 
 # Lehetséges csak bizonyos függvényeket importálni egy modulból
 from math import ceil, floor

--- a/it-it/python-it.html.markdown
+++ b/it-it/python-it.html.markdown
@@ -640,7 +640,7 @@ i.age  # => Emette un AttributeError
 
 # Puoi importare moduli
 import math
-print math.sqrt(16)  # => 4
+print math.sqrt(16)  # => 4.0
 
 # Puoi ottenere specifiche funzione da un modulo
 from math import ceil, floor

--- a/ko-kr/python-kr.html.markdown
+++ b/ko-kr/python-kr.html.markdown
@@ -441,7 +441,7 @@ Human.grunt() #=> "*grunt*"
 
 # 다음과 같이 모듈을 임포트할 수 있습니다.
 import math
-print math.sqrt(16) #=> 4
+print math.sqrt(16) #=> 4.0
 
 # 모듈의 특정 함수를 호출할 수 있습니다.
 from math import ceil, floor

--- a/pl-pl/python-pl.html.markdown
+++ b/pl-pl/python-pl.html.markdown
@@ -532,7 +532,7 @@ Czlowiek.grunt()   # => "*grunt*"
 
 # Tak importuje się moduły:
 import math
-print(math.sqrt(16))  # => 4
+print(math.sqrt(16))  # => 4.0
 
 # Można podać konkretne funkcje, np. ceil, floor z modułu math
 from math import ceil, floor

--- a/pt-br/python-pt.html.markdown
+++ b/pt-br/python-pt.html.markdown
@@ -464,7 +464,7 @@ Humano.ronca() #=> "*arrrrrrr*"
 
 # Você pode importar módulos
 import math
-print math.sqrt(16) #=> 4
+print math.sqrt(16) #=> 4.0
 
 # Você pode importar funções específicas de um módulo
 from math import ceil, floor

--- a/pt-br/python3-pt.html.markdown
+++ b/pt-br/python3-pt.html.markdown
@@ -647,7 +647,7 @@ Human.grunt()    # => "*grunt*"
 
 # Você pode importar módulos
 import math
-print(math.sqrt(16))  # => 4
+print(math.sqrt(16))  # => 4.0
 
 # Você pode importar apenas funções específicas de um módulo
 from math import ceil, floor

--- a/python.html.markdown
+++ b/python.html.markdown
@@ -661,7 +661,7 @@ i.age  # => raises an AttributeError
 # You can import modules
 import math
 
-print math.sqrt(16)  # => 4
+print math.sqrt(16)  # => 4.0
 
 # You can get specific functions from a module
 from math import ceil, floor

--- a/ro-ro/python-ro.html.markdown
+++ b/ro-ro/python-ro.html.markdown
@@ -449,7 +449,7 @@ Om.exclama() #=> "*Aaaaaah*"
 
 # Pentru a folosi un modul, trebuie importat 
 import math
-print math.sqrt(16) #=> 4
+print math.sqrt(16) #=> 4.0
 
 # Putem importa doar anumite funcţii dintr-un modul 
 from math import ceil, floor

--- a/ru-ru/python-ru.html.markdown
+++ b/ru-ru/python-ru.html.markdown
@@ -541,7 +541,7 @@ Human.grunt() #=> "*grunt*"
 
 # Вы можете импортировать модули
 import math
-print(math.sqrt(16)) #=> 4
+print(math.sqrt(16)) #=> 4.0
 
 # Вы можете импортировать отдельные функции модуля
 from math import ceil, floor

--- a/tr-tr/python-tr.html.markdown
+++ b/tr-tr/python-tr.html.markdown
@@ -458,7 +458,7 @@ Human.grunt() #=> "*grunt*"
 
 # Modülleri sayfaya dahil edebilirsiniz
 import math
-print math.sqrt(16) #=> 4
+print math.sqrt(16) #=> 4.0
 
 # Modül içerisinden spesifik bir fonksiyonu getirebilirsiniz
 from math import ceil, floor

--- a/uk-ua/python-ua.html.markdown
+++ b/uk-ua/python-ua.html.markdown
@@ -654,7 +654,7 @@ i.age  # => виникає помилка атрибуту
 # Ви можете імпортувати модулі
 import math
 
-print(math.sqrt(16))  # => 4
+print(math.sqrt(16))  # => 4.0
 
 # Ви можете імпортувати окремі функції з модуля
 from math import ceil, floor

--- a/zh-cn/python-cn.html.markdown
+++ b/zh-cn/python-cn.html.markdown
@@ -439,7 +439,7 @@ Human.grunt()  # => "*grunt*"
 
 # 我们可以导入其他模块
 import math
-print math.sqrt(16)  # => 4
+print math.sqrt(16)  # => 4.0
 
 # 我们也可以从一个模块中导入特定的函数
 from math import ceil, floor

--- a/zh-tw/python-tw.html.markdown
+++ b/zh-tw/python-tw.html.markdown
@@ -627,7 +627,7 @@ i.age  # => raises an AttributeError
 
 # 你可以引入模組來做使用
 import math
-print math.sqrt(16)  # => 4
+print math.sqrt(16)  # => 4.0
                      # math.sqrt()為取根號
 
 # 你可以只從模組取出特定幾個函式


### PR DESCRIPTION
Both in Python 2.7.10 and Python 3.6.5, math.sqrt() returns a float and not int. It seems like a tiny thing but sometimes may lead up to bigger confusions. For example: https://stackoverflow.com/questions/54474037/why-are-the-following-codes-giving-me-different-output-square-root-big-numbers/54475501#54475501

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
