### PR TITLE
[powershell/en] Fix typo in powershell page

### DIFF
--- a/powershell.html.markdown
+++ b/powershell.html.markdown
@@ -245,7 +245,7 @@ function New-Website() {
 'string' | gm
 
 # Syntax for calling static .NET methods
-\[System.Reflection.Assembly]::LoadWithPartialName('Microsoft.VisualBasic')
+[System.Reflection.Assembly]::LoadWithPartialName('Microsoft.VisualBasic')
 
 # Note that .NET functions MUST be called with parentheses
 # while PS functions CANNOT be called with parentheses.


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!

There was a stray backslash in the powershell page. The Spanish version didn't have this issue.