### PR TITLE
[crystal/en] Add new Int128 and UInt128 types

### DIFF
--- a/crystal.html.markdown
+++ b/crystal.html.markdown
@@ -25,17 +25,19 @@ true.class #=> Bool
 
 1.class #=> Int32
 
-# Four signed integer types
-1_i8.class  #=> Int8
-1_i16.class #=> Int16
-1_i32.class #=> Int32
-1_i64.class #=> Int64
+# Five signed integer types
+1_i8.class   #=> Int8
+1_i16.class  #=> Int16
+1_i32.class  #=> Int32
+1_i64.class  #=> Int64
+1_i128.class #=> Int128
 
-# Four unsigned integer types
-1_u8.class  #=> UInt8
-1_u16.class #=> UInt16
-1_u32.class #=> UInt32
-1_u64.class #=> UInt64
+# Five unsigned integer types
+1_u8.class   #=> UInt8
+1_u16.class  #=> UInt16
+1_u32.class  #=> UInt32
+1_u64.class  #=> UInt64
+1_u128.class #=> UInt128
 
 2147483648.class          #=> Int64
 9223372036854775808.class #=> UInt64


### PR DESCRIPTION
Sources for the change:
https://crystal-lang.org/api/0.27.2/UInt128.html
https://crystal-lang.org/api/0.27.2/Int128.html

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] YAML Frontmatter not applicable