### PR TITLE
[julia/en] Add note about integer overflow

### DIFF
--- a/julia.html.markdown
+++ b/julia.html.markdown
@@ -46,6 +46,13 @@ div(5, 2)  # => 2    # for a truncated result, use div
 # Enforce precedence with parentheses
 (1 + 3) * 2  # => 8
 
+# Julia (unlike Python for instance) has integer under/overflow
+10^19      # => -8446744073709551616
+# use bigint or floating point to avoid this
+big(10)^19 # => 10000000000000000000
+1e19       # => 1.0e19
+10.0^19    # => 1.0e19
+
 # Bitwise Operators
 ~2         # => -3 # bitwise not
 3 & 5      # => 1  # bitwise and


### PR DESCRIPTION
Something that may trip users coming from a Python background as per https://discourse.julialang.org/t/julia-messes-up-integer-exponents/20773

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
