### PR TITLE
[Global] Update tools category

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -52,6 +52,8 @@ languages:
 
 Other fields:
 
+- **category**: The category of the article. So far, can be one of *language*,
+  *tool* or *Algorithms & Data Structures*. Defaults to *language* if omitted.
 - **filename**: The filename for this article's code. It will be fetched, mashed
   together, and made downloadable.
     + For non-English articles, *filename* should   have a language-specific 

--- a/awk.html.markdown
+++ b/awk.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: awk
+category: tool
+tool: awk
 filename: learnawk.awk
 contributors:
      - ["Marshall Mason", "http://github.com/marshallmason"]

--- a/cmake.html.markdown
+++ b/cmake.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: cmake
+category: tool
+tool: cmake
 contributors:
     - ["Bruno Alano", "https://github.com/brunoalano"]
 filename: CMake

--- a/de-de/make-de.html.markdown
+++ b/de-de/make-de.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: make
+category: tool
+tool: make
 contributors:
     - ["Robert Steed", "https://github.com/robochat"]
     - ["Stephan Fuhrmann", "https://github.com/sfuhrm"]

--- a/es-es/awk-es.html.markdown
+++ b/es-es/awk-es.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: awk
+category: tool
+tool: awk
 filename: learnawk-es.awk
 contributors:
     - ["Marshall Mason", "http://github.com/marshallmason"]

--- a/es-es/pythonstatcomp-es.html.markdown
+++ b/es-es/pythonstatcomp-es.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: Statistical computing with Python
+category: tool
+tool: Statistical Computing with Python
 contributors:
     - ["e99n09", "https://github.com/e99n09"]
 filename: pythonstatcomp-es.py

--- a/fr-fr/awk-fr.html.markdown
+++ b/fr-fr/awk-fr.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: awk
+category: tool
+tool: awk
 filename: learnawk-fr.awk
 contributors:
      - ["Marshall Mason", "http://github.com/marshallmason"]

--- a/fr-fr/make-fr.html.markdown
+++ b/fr-fr/make-fr.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: make
+category: tool
+tool: make
 contributors:
     - ["Robert Steed", "https://github.com/robochat"]
 translators:

--- a/make.html.markdown
+++ b/make.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: make
+category: tool
+tool: make
 contributors:
     - ["Robert Steed", "https://github.com/robochat"]
     - ["Stephan Fuhrmann", "https://github.com/sfuhrm"]

--- a/pt-br/awk-pt.html.markdown
+++ b/pt-br/awk-pt.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: awk
+category: tool
+tool: awk
 filename: learnawk-pt.awk
 contributors:
     - ["Marshall Mason", "http://github.com/marshallmason"]

--- a/pt-br/cmake-pt.html.markdown
+++ b/pt-br/cmake-pt.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: cmake
+category: tool
+tool: cmake
 contributors:
     - ["Bruno Alano", "https://github.com/brunoalano"]
 filename: CMake-br

--- a/pt-br/make-pt.html.markdown
+++ b/pt-br/make-pt.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: make
+category: tool
+tool: make
 contributors:
     - ["Robert Steed", "https://github.com/robochat"]
     - ["Stephan Fuhrmann", "https://github.com/sfuhrm"]

--- a/tcsh.html.markdown
+++ b/tcsh.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: tcsh
+category: tool
+tool: tcsh
 filename: LearnTCSH.csh
 contributors:
        - ["Nicholas Christopoulos", "https://github.com/nereusx"]

--- a/zh-cn/awk-cn.html.markdown
+++ b/zh-cn/awk-cn.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: awk
+category: tool
+tool: awk
 contributors:
      - ["Marshall Mason", "http://github.com/marshallmason"]
 translators:

--- a/zh-cn/make-cn.html.markdown
+++ b/zh-cn/make-cn.html.markdown
@@ -1,5 +1,6 @@
 ---
-language: make
+category: tool
+tool: make
 contributors:
 - ["Robert Steed", "https://github.com/robochat"]
 - ["Jichao Ouyang", "https://github.com/jcouyang"]


### PR DESCRIPTION
Move the following articles:

- awk _(main, es-es, fr-fr, pt-br, zh-cn)_
- cmake _(main, pt-br)_
- make _(main, de-de, fr-fr, pt-br, zh-cn)_
- tcsh _(main)_
- Statistical Computing with Python _(es-es)_

... to the "tools" category.

Bonus: the ES translation of "Statistical Computing with Python" didn't show up on the homepage because "Computing" was written with a lowercase "C" whereas it's a capital C in the english article -- fixed this.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!