### PR TITLE
[elisp/en] t evaluates to itself, so it doesn't need to be quoted

### DIFF
--- a/elisp.html.markdown
+++ b/elisp.html.markdown
@@ -281,7 +281,7 @@ filename: learn-emacs-lisp.el
 ;; should stop searching at some point in the buffer, and whether it
 ;; should silently fail when nothing is found:
 
-;; (search-forward "Hello" nil 't) does the trick:
+;; (search-forward "Hello" nil t) does the trick:
 
 ;; The `nil' argument says: the search is not bound to a position.
 ;; The `'t' argument says: silently fail when nothing is found.
@@ -295,7 +295,7 @@ filename: learn-emacs-lisp.el
     (mapcar 'hello list-of-names)
     (goto-char (point-min))
     ;; Replace "Hello" by "Bonjour"
-    (while (search-forward "Hello" nil 't)
+    (while (search-forward "Hello" nil t)
       (replace-match "Bonjour"))
     (other-window 1))
 
@@ -306,7 +306,7 @@ filename: learn-emacs-lisp.el
 (defun boldify-names ()
     (switch-to-buffer-other-window "*test*")
     (goto-char (point-min))
-    (while (re-search-forward "Bonjour \\(.+\\)!" nil 't)
+    (while (re-search-forward "Bonjour \\(.+\\)!" nil t)
       (add-text-properties (match-beginning 1)
                            (match-end 1)
                            (list 'face 'bold)))


### PR DESCRIPTION
https://www.gnu.org/software/emacs/manual/html_node/elisp/nil-and-t.html

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
