### PR TITLE
Updated initialiser

### DIFF
--- a/chapel.html.markdown
+++ b/chapel.html.markdown
@@ -708,7 +708,7 @@ class MyClass {
 // We also get the compiler-generated initializer, with one argument per field.
 // Note that soon there will be no compiler-generated initializer when we
 // define any initializer(s) explicitly.
-  proc MyClass(val : real) {
+  proc init(val : real) {
     this.memberInt = ceil(val): int;
   }
 


### PR DESCRIPTION
Constructors have been deprecated as of Chapel 1.18