### PR TITLE
(fsharp/en) List Pattern Matching first element of "many"

### DIFF
--- a/fsharp.html.markdown
+++ b/fsharp.html.markdown
@@ -194,7 +194,7 @@ module ListExamples =
         | [] -> printfn "the list is empty"
         | [first] -> printfn "the list has one element %A " first
         | [first; second] -> printfn "list is %A and %A" first second
-        | _ -> printfn "the list has more than two elements"
+        | first :: _ -> printfn "the list has more than two elements, first element %A" first
 
     listMatcher [1; 2; 3; 4]
     listMatcher [1; 2]


### PR DESCRIPTION
Updated the pattern matching for lists to show how to get head of a list when you don't care how many other elements are in the list.

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
