### PR TITLE
[perl5/en] Fixed variable not declared before use.

### DIFF
--- a/perl.html.markdown
+++ b/perl.html.markdown
@@ -152,7 +152,7 @@ while (condition) {
   ...
 }
 
-
+my $max = 5;
 # for loops and iteration
 for my $i (0 .. $max) {
   print "index is $i";


### PR DESCRIPTION
The variable `max` was not declared before use in demonstrating how for loops work over ranges.  It has been added on line 155 and set to a value of 5

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
