### PR TITLE
[perl6/en] Fixed output 

### DIFF
--- a/perl6.html.markdown
+++ b/perl6.html.markdown
@@ -247,11 +247,12 @@ concat3(|@array); #=> a, b, c
 ## arguments. If you really need to, you can ask for a mutable container by
 ## using the `is rw` trait:
 sub mutate( $n is rw ) {
-    $n++;
+    $n++; # postfix ++ operator increments its argument but returns its old value
 }
 
 my $m = 42;
-mutate $m; #=> 43
+mutate $m; # the value is incremented but the old value is returned
+           #=> 42
 say $m;    #=> 43
 
 ## This works because we are passing the container $m to the `mutate` sub.


### PR DESCRIPTION
The postfix ++ operator increments its argument but returns its old value. In the document, after incrementing a container with value 42, it said it would output 43. However it outputs 42.
https://docs.perl6.org/language/operators#postfix_++

- [ ] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
