### PR TITLE
[yaml/en] UTF-8/16/32 characters need to be encoded

### DIFF
--- a/yaml.html.markdown
+++ b/yaml.html.markdown
@@ -38,6 +38,8 @@ however: 'A string, enclosed in quotes.'
 'Keys can be quoted too.': "Useful if you want to put a ':' in your key."
 single quotes: 'have ''one'' escape pattern'
 double quotes: "have many: \", \0, \t, \u263A, \x0d\x0a == \r\n, and more."
+# UTF-8/16/32 characters need to be encoded
+Superscript two: \u00B2
 
 # Multiple-line strings can be written either as a 'literal block' (using |),
 # or a 'folded block' (using '>').


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!

I was a bit confused whether I needed to manually encode utf-8/16/32 characters in yaml. This site states only ascii is supported:
https://docs.saltstack.com/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html#yaml-supports-only-plain-ascii

Linters / validators like listed below however don't mark yaml with utf-8/16/32 characters as invalid.
http://www.yamllint.com/
https://yamlvalidator.com/

The following stack overflow states that the encoding is done at the file level and is transparent to the YAML and its parsing.
https://stackoverflow.com/a/648335/1544200

In a personal project I've found no issues when including utf-8/16/32 characters like æ, ² directly in yaml. 

So I'm not sure... I hope we can add something to the yaml examples that can clarify this. 