### PR TITLE
[typescript/en] Fixed int array output which was shown as string

### DIFF
--- a/typescript.html.markdown
+++ b/typescript.html.markdown
@@ -235,13 +235,13 @@ for (const val of arrayOfAnyType) {
 
 let list = [4, 5, 6];
 for (const i of list) {
-   console.log(i); // "4", "5", "6"
+   console.log(i); // 4, 5, 6
 }
 
 // for..in statement
 // iterate over the list of keys on the object being iterated
 for (const i in list) {
-   console.log(i); // "0", "1", "2",
+   console.log(i); // 0, 1, 2
 }
 
 


### PR DESCRIPTION
The input list is of int[] [@line236](https://github.com/adambard/learnxinyminutes-docs/blame/master/typescript.html.markdown#L236]) but the output of its shown is in string [@line238](https://github.com/adambard/learnxinyminutes-docs/blame/master/typescript.html.markdown#L238]). same thing happens at [@line244](https://github.com/adambard/learnxinyminutes-docs/blame/master/typescript.html.markdown#L244])


- [x]  I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
