### PR TITLE
[Rust/en] minor fixes to string slices and borrow system

### DIFF
--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -92,10 +92,8 @@ fn main() {
     let s: String = "hello world".to_string();
 
     // A string slice – an immutable view into another string
-    // This is basically an immutable pair of pointers to a string – it doesn’t
-    // actually contain the contents of a string, just a pointer to
-    // the begin and a pointer to the end of a string buffer,
-    // statically allocated or contained in another object (in this case, `s`)
+    // The string buffer can be statically allocated like in a string literal
+    // or contained in another object (in this case, `s`)
     let s_slice: &str = &s;
 
     println!("{} {}", s, s_slice); // hello world hello world

--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -288,7 +288,7 @@ fn main() {
     // Reference – an immutable pointer that refers to other data
     // When a reference is taken to a value, we say that the value has been ‘borrowed’.
     // While a value is borrowed immutably, it cannot be mutated or moved.
-    // A borrow lasts until the end of the scope it was created in.
+    // A borrow is active until the last use of the borrowing variable.
     let mut var = 4;
     var = 3;
     let ref_var: &i32 = &var;
@@ -297,6 +297,8 @@ fn main() {
     println!("{}", *ref_var);
     // var = 5; // this would not compile because `var` is borrowed
     // *ref_var = 6; // this would not either, because `ref_var` is an immutable reference
+    ref_var; // no-op, but counts as a use and keeps the borrow active
+    var = 2; // ref_var is no longer used after the line above, so the borrow has ended
 
     // Mutable reference
     // While a value is mutably borrowed, it cannot be accessed at all.
@@ -307,6 +309,7 @@ fn main() {
     println!("{}", *ref_var2); // 6 , // var2 would not compile.
     // ref_var2 is of type &mut i32, so stores a reference to an i32, not the value.
     // var2 = 2; // this would not compile because `var2` is borrowed.
+    ref_var2; // no-op, but counts as a use and keeps the borrow active until here
 }
 ```
 


### PR DESCRIPTION
- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)

This PR contains 2 small fixes:
1. Explanation of string slices:
    Slices (string slices included) are not backed by two pointers but a pointer and a length. I also found this comment to be misleading: "[a slice] doesn’t actually contain the contents of a string, just a pointer to the begin[ning]". That is not a special or defining characteristic of a string slice. `String`s also just contain a pointer to the data, a length and a capacity. The real difference lies in ownership, but it's too early for that explanation.  
   Apart from the factual content, it's extraneous detail so I shortened the comment.

2. Lifetime system
    The lifetime system is no longer bound to scopes. I've updated the explanation. Several of the examples that are commented out and are supposed to cause compile errors no longer do. I've added no-op uses of the references to extend the borrows past them so that they will error again.