### PR TITLE
[python/en] don't overwrite list function

### DIFF
--- a/python3.html.markdown
+++ b/python3.html.markdown
@@ -466,8 +466,8 @@ prints:
     1 cat
     2 mouse
 """
-list = ["dog", "cat", "mouse"]
-for i, value in enumerate(list):
+animals = ["dog", "cat", "mouse"]
+for i, value in enumerate(animals):
     print(i, value)
 
 """


### PR DESCRIPTION
problem:
assigning a list of animals to the list variable overwrites the list function, so that later in line 531 the list function is not available and raises a Type Error:
```
In [133]: list(filled_dict.keys())
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-133-a2c520b90051> in <module>
----> 1 list(filled_dict.keys())

TypeError: 'list' object is not callable
```
solution:
use another variable name instead of list

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
