### PR TITLE
[en/sass] Update Sass Example to use proper syntax highlighting

### DIFF
--- a/sass.html.markdown
+++ b/sass.html.markdown
@@ -16,7 +16,7 @@ This tutorial is written using SCSS.
 
 If you're already familiar with CSS3, you'll be able to pick up Sass relatively quickly. It does not provide any new styling properties but rather the tools to write your CSS more efficiently and make maintenance much easier.
 
-```sass
+```scss
 
 
 //Single line comments are removed when Sass is compiled to CSS.


### PR DESCRIPTION
SUPER minor change!

The SASS documentation says:

>Sass has two different syntax options to choose from. SCSS, which has the same syntax as CSS but with the added features of Sass. Or Sass (the original syntax), which uses indentation rather than curly braces and semicolons. This tutorial is written using SCSS.

However, the markdown codeblock was using `sass` for the syntax highlighting.  This caused all the `;` to be marked as errors.  This change changes the highlighting to `scss` so there are no errors in the formatting.



- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
