### PR TITLE
[typescript/en] Fix playground link

### DIFF
--- a/typescript.html.markdown
+++ b/typescript.html.markdown
@@ -16,7 +16,7 @@ This article will focus only on TypeScript extra syntax, as opposed to
 [JavaScript](/docs/javascript).
 
 To test TypeScript's compiler, head to the
-[Playground] (http://www.typescriptlang.org/Playground) where you will be able
+[Playground](http://www.typescriptlang.org/Playground) where you will be able
 to type code, have auto completion and directly see the emitted JavaScript.
 
 ```ts

--- a/typescript.html.markdown
+++ b/typescript.html.markdown
@@ -16,7 +16,7 @@ This article will focus only on TypeScript extra syntax, as opposed to
 [JavaScript](/docs/javascript).
 
 To test TypeScript's compiler, head to the
-[Playground](http://www.typescriptlang.org/Playground) where you will be able
+[Playground](https://www.typescriptlang.org/play) where you will be able
 to type code, have auto completion and directly see the emitted JavaScript.
 
 ```ts


### PR DESCRIPTION
Found a small error in the TS documentation.  There was an extra space causing the markdown link rendering to be incorrect! 

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
