### PR TITLE
[Go,Cypher/en-us,uk-ua] Fix Cypher and Go source code download as uk-ua language

### DIFF
--- a/uk-ua/cypher-ua.html.markdown
+++ b/uk-ua/cypher-ua.html.markdown
@@ -1,6 +1,6 @@
 ---
 language: cypher
-filename: LearnCypher.cql
+filename: LearnCypher-ua.cql
 contributors:
     - ["Théo Gauchoux", "https://github.com/TheoGauchoux"]
 translators:

--- a/uk-ua/go-ua.html.markdown
+++ b/uk-ua/go-ua.html.markdown
@@ -2,7 +2,7 @@
 name: Go
 category: language
 language: Go
-filename: learngo.go
+filename: learngo-ua.go
 contributors:
     - ["Sonia Keys", "https://github.com/soniakeys"]
     - ["Christopher Bess", "https://github.com/cbess"]


### PR DESCRIPTION
Wasn't sure how to prepend this PR as it affects multiple programming languages, and concerns multiple world languages

Attempted to download the Go source code at https://learnxinyminutes.com/docs/go/ earlier, and noticed that the source code file was in Ukrainian instead of English. Fixed in a commit and then noticed that Cypher had the same incorrect filename, and sure enough downloading the Cypher source code at https://learnxinyminutes.com/docs/cypher/ downloads the Ukrainian version instead of English.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!