### PR TITLE
[language/reason] fix typo

### DIFF
--- a/reason.html.markdown
+++ b/reason.html.markdown
@@ -162,7 +162,7 @@ let maxPassengers = firstTrip.capacity;
 
 /* If you define the record type in a different file, you have to reference the
    filename, if trainJourney was in a file called Trips.re */
-let secondTrip: Trips.firstTrip = {
+let secondTrip: Trips.trainJourney = {
   destination: "Paris",
   capacity: 50,
   averageSpeed: 150.0,


### PR DESCRIPTION
the type of secondTrip should be Trips.trainJourney, not Trips.firstTrip.

trainJourney is a proper type, whereas firstTrip is a variable

- [*] I solemnly swear that this is all original content of which I am the original author
- [*] Pull request title is prepended with `[language/lang-code]`
- [*] Pull request touches only one file (or a set of logically related files with similar changes made)
- [*] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [*] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [*] Yes, I have double-checked quotes and field names!
