### PR TITLE
[swift/en] Return value of `findIndex` is `Optional<Int>`

### DIFF
--- a/swift.html.markdown
+++ b/swift.html.markdown
@@ -904,7 +904,7 @@ func findIndex<T: Equatable>(array: [T], valueToFind: T) -> Int? {
     }
     return nil
 }
-findIndex(array: [1, 2, 3, 4], valueToFind: 3) // 2
+findIndex(array: [1, 2, 3, 4], valueToFind: 3) // Optional(2)
 
 // You can extend types with generics as well
 extension Array where Array.Element == Int {


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!

Thanks for this valuable resource! I noticed that the return value of the `findIndex` function should have been an `Optional` — this PR makes that change.
