### PR TITLE
[ruby/en] Fix typo in ruby.html.markdown

### DIFF
--- a/ruby.html.markdown
+++ b/ruby.html.markdown
@@ -410,7 +410,7 @@ def guests(&block)
 end
 
 # The 'call' method on the Proc is similar to calling 'yield' when a block is 
-# present. The arguments passed to 'call' will be forwarded to the block as arugments.
+# present. The arguments passed to 'call' will be forwarded to the block as arguments.
 
 guests { |n| "You have #{n} guests." }
 # => "You have 4 guests."


### PR DESCRIPTION
"arugments" => "arguments"

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
