### PR TITLE
[standard-ml/en] Fix broken author homepage links, add Exercism.io link

### DIFF
--- a/standard-ml.html.markdown
+++ b/standard-ml.html.markdown
@@ -2,8 +2,8 @@
 language: "Standard ML"
 filename: standardml.sml
 contributors:
-    - ["Simon Shine", "http://shine.eu.org/"]
-    - ["David Pedersen", "http://lonelyproton.com/"]
+    - ["Simon Shine", "https://simonshine.dk/"]
+    - ["David Pedersen", "https://github.com/davidpdrsn"]
     - ["James Baker", "http://www.jbaker.io/"]
     - ["Leo Zovic", "http://langnostic.inaimathi.ca/"]
     - ["Chris Wilson", "http://sencjw.com/"]
@@ -479,3 +479,4 @@ fun decrement_ret x y = (x := !x - 1; y)
 * Follow the Coursera course [Programming Languages](https://www.coursera.org/course/proglang).
 * Read *[ML for the Working Programmer](https://www.cl.cam.ac.uk/~lp15/MLbook/pub-details.html)* by Larry C. Paulson.
 * Use [StackOverflow's sml tag](http://stackoverflow.com/questions/tagged/sml).
+* Solve exercises on [Exercism.io's Standard ML track](https://exercism.io/tracks/sml).


### PR DESCRIPTION
The homepages for @sshine and @davidpdrsn were broken.

Add "Further reading" link to Exercism.io's SML track.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
