### PR TITLE
[make/de-de] Fixed typos and comma errors

### DIFF
--- a/de-de/make-de.html.markdown
+++ b/de-de/make-de.html.markdown
@@ -11,14 +11,14 @@ lang: de-de
 ---
 
 Eine Makefile definiert einen Graphen von Regeln um ein Ziel (oder Ziele)
-zu erzeugen. Es dient dazu die geringste Menge an Arbeit zu verrichten um
-ein Ziel in einklang mit dem Quellcode zu bringen. Make wurde berühmterweise
+zu erzeugen. Es dient dazu, die geringste Menge an Arbeit zu verrichten um
+ein Ziel in Einklang mit dem Quellcode zu bringen. Make wurde berühmterweise
 von Stuart Feldman 1976 übers Wochenende geschrieben. Make ist noch immer
-sehr verbreitet (vorallem im Unix umfeld) obwohl es bereits sehr viel
+sehr verbreitet (vorallem im Unix Umfeld) obwohl es bereits sehr viel
 Konkurrenz und Kritik zu Make gibt.
 
-Es gibt eine vielzahl an Varianten von Make, dieser Artikel beschäftig sich
-mit der Version GNU Make. Diese Version ist standard auf Linux.
+Es gibt eine Vielzahl an Varianten von Make, dieser Artikel beschäftigt sich
+mit der Version GNU Make. Diese Version ist Standard auf Linux.
 
 ```make
 
@@ -44,14 +44,15 @@ file0.txt:
 	# die erste Regel ist die Standard-Regel.
 
 
-# Diese Regel wird nur abgearbeitet wenn file0.txt aktueller als file1.txt ist.
+# Diese Regel wird nur abgearbeitet, wenn file0.txt aktueller als file1.txt ist.
 file1.txt: file0.txt
 	cat file0.txt > file1.txt
 	# Verwende die selben Quoting-Regeln wie die Shell
 	@cat file0.txt >> file1.txt
 	# @ unterdrückt die Ausgabe des Befehls an stdout.
 	-@echo 'hello'
-	# - bedeutet das Make die Abarbeitung fortsetzt auch wenn Fehler passieren.
+	# - bedeutet, dass Make die Abarbeitung fortsetzt auch wenn Fehler
+    # passieren.
 	# Versuche `make file1.txt` auf der Kommandozeile.
 
 # Eine Regel kann mehrere Ziele und mehrere Voraussetzungen haben.
@@ -59,7 +60,7 @@ file2.txt file3.txt: file0.txt file1.txt
 	touch file2.txt
 	touch file3.txt
 
-# Make wird sich beschweren wenn es mehrere Rezepte für die gleiche Regel gibt.
+# Make wird sich beschweren, wenn es mehrere Rezepte für die gleiche Regel gibt.
 # Leere Rezepte zählen nicht und können dazu verwendet werden weitere
 # Voraussetzungen hinzuzufügen.
 
@@ -67,8 +68,8 @@ file2.txt file3.txt: file0.txt file1.txt
 # Phony-Ziele
 #-----------------------------------------------------------------------
 
-# Ein Phony-Ziel ist ein Ziel das keine Datei ist.
-# Es wird nie aktuell sein, daher wird Make immer versuchen es abzuarbeiten
+# Ein Phony-Ziel ist ein Ziel, das keine Datei ist.
+# Es wird nie aktuell sein, daher wird Make immer versuchen, es abzuarbeiten
 all: maker process
 
 # Es ist erlaubt Dinge ausserhalb der Reihenfolge zu deklarieren.
@@ -89,14 +90,14 @@ ex0.txt ex1.txt: maker
 # Automatische Variablen & Wildcards
 #-----------------------------------------------------------------------
 
-process: file*.txt	# Eine Wildcard um Dateinamen zu Vergleichen
+process: file*.txt	# Eine Wildcard um Dateinamen zu vergleichen
 	@echo $^	# $^ ist eine Variable die eine Liste aller
 			# Voraussetzungen enthält.
 	@echo $@	# Namen des Ziels ausgeben.
 	#(Bei mehreren Ziel-Regeln enthält $@ den Verursacher der Abarbeitung
 	#der Regel.)
 	@echo $<	# Die erste Voraussetzung aus der Liste
-	@echo $?	# Nur die Voraussetzungen die nicht aktuell sind.
+	@echo $?	# Nur die Voraussetzungen, die nicht aktuell sind.
 	@echo $+	# Alle Voraussetzungen inklusive Duplikate (nicht wie Üblich)
 	#@echo $|	# Alle 'order only' Voraussetzungen
 
@@ -114,20 +115,20 @@ process: ex1.txt file0.txt
 %.png: %.svg
 	inkscape --export-png $^
 
-# Muster-Vergleichs-Regeln werden nur abgearbeitet wenn make entscheidet das Ziel zu
-# erzeugen
+# Muster-Vergleichs-Regeln werden nur abgearbeitet, wenn make entscheidet das
+# Ziel zu erzeugen
 
 # Verzeichnis-Pfade werden normalerweise bei Muster-Vergleichs-Regeln ignoriert.
 # Aber make wird versuchen die am besten passende Regel zu verwenden.
 small/%.png: %.svg
 	inkscape --export-png --export-dpi 30 $^
 
-# Make wird die letzte Version einer Muster-Vergleichs-Regel verwenden die es
+# Make wird die letzte Version einer Muster-Vergleichs-Regel verwenden, die es
 # findet.
 %.png: %.svg
 	@echo this rule is chosen
 
-# Allerdings wird make die erste Muster-Vergleicher-Regel verwenden die das
+# Allerdings wird make die erste Muster-Vergleicher-Regel verwenden, die das
 # Ziel erzeugen kann.
 %.png: %.ps
 	@echo this rule is not chosen if *.svg and *.ps are both present
@@ -171,7 +172,7 @@ name4 ?= Jean
 # nicht gibt.
 
 override name5 = David
-# Verhindert das Kommando-Zeilen Argumente diese Variable ändern können.
+# Verhindert, dass Kommando-Zeilen Argumente diese Variable ändern können.
 
 name4 +=grey
 # Werte an eine Variable anhängen (inkludiert Leerzeichen).
@@ -179,9 +180,9 @@ name4 +=grey
 # Muster-Spezifische Variablen Werte (GNU Erweiterung).
 echo: name2 = Sara # Wahr innerhalb der passenden Regel und auch innerhalb
 	# rekursiver Voraussetzungen (ausser wenn es den Graphen zerstören
-	# kann wenn es zu kompilizert wird!)
+	# kann, wenn es zu kompilizert wird!)
 
-# Ein paar Variablen die von Make automatisch definiert werden.
+# Ein paar Variablen, die von Make automatisch definiert werden.
 echo_inbuilt:
 	echo $(CC)
 	echo ${CXX}
@@ -196,7 +197,7 @@ echo_inbuilt:
 # Variablen 2
 #-----------------------------------------------------------------------
 
-# Der erste Typ von Variablen wird bei jeder verwendung ausgewertet.
+# Der erste Typ von Variablen wird bei jeder Verwendung ausgewertet.
 # Das kann aufwendig sein, daher exisitert ein zweiter Typ von Variablen.
 # Diese werden nur einmal ausgewertet. (Das ist eine GNU make Erweiterung)
 
@@ -215,7 +216,7 @@ var4 ::= good night
 # Funktionen
 #-----------------------------------------------------------------------
 
-# Make verfügt über eine vielzahl von Funktionen.
+# Make verfügt über eine Vielzahl von Funktionen.
 
 sourcefiles = $(wildcard *.c */*.c)
 objectfiles = $(patsubst %.c,%.o,$(sourcefiles))


### PR DESCRIPTION
I have fixed some typos and comma errors in make

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
