### PR TITLE
[rust/en] Change misleading method and add two other methods

### DIFF
--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -176,7 +176,13 @@ fn main() {
 
     impl<T> Foo<T> {
         // Methods take an explicit `self` parameter
-        fn get_bar(self) -> T {
+        fn bar(&self) -> &T { // self is borrowed
+            &self.bar
+        }
+        fn bar_mut(&mut self) -> &mut T { // self is mutably borrowed
+            &mut self.bar
+        }
+        fn into_bar(self) -> T { // here self is consumed
             self.bar
         }
     }

--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -188,7 +188,7 @@ fn main() {
     }
 
     let a_foo = Foo { bar: 1 };
-    println!("{}", a_foo.get_bar()); // 1
+    println!("{}", a_foo.bar()); // 1
 
     // Traits (known as interfaces or typeclasses in other languages) //
 


### PR DESCRIPTION
The `get_bar` method consumes `self`. The name is misleading and does not respect the language naming convention.

This PR renames it to `into_bar` and provides `bar` (a getter) and `bar_mut` (to get a mutable reference).

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
