### PR TITLE
[crystal/en] Fixed typo and reference url

### DIFF
--- a/crystal.html.markdown
+++ b/crystal.html.markdown
@@ -229,7 +229,7 @@ b #=> 'b'
 c #=> "c"
 
 # Procs represent a function pointer with an optional context (the closure data)
-# It is typically created with a proc litteral
+# It is typically created with a proc literal
 proc = ->(x : Int32) { x.to_s }
 proc.class # Proc(Int32, String)
 # Or using the new method

--- a/crystal.html.markdown
+++ b/crystal.html.markdown
@@ -551,4 +551,4 @@ ex #=> "ex2"
 
 ## Additional resources
 
-- [Official Documentation](http://crystal-lang.org/)
+- [Official Documentation](https://crystal-lang.org/)


### PR DESCRIPTION
I have fixed a small typo and changed the reference url to https.

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
