### PR TITLE
[groovy/en] Small typo fix in Groovy document

### DIFF
--- a/groovy.html.markdown
+++ b/groovy.html.markdown
@@ -184,7 +184,7 @@ class Foo {
   Methods with optional parameters
 */
 
-// A mthod can have default values for parameters
+// A method can have default values for parameters
 def say(msg = 'Hello', name = 'world') {
     "$msg $name!"
 }


### PR DESCRIPTION
Changed _"mthod"_ to _"method"_.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!