### PR TITLE
[nix/en] Fix typo in nix documentation

### DIFF
--- a/nix.html.markdown
+++ b/nix.html.markdown
@@ -279,7 +279,7 @@ with builtins; [
   #=> 7
 
   # This first line of tutorial starts with "with builtins;"
-  # because builtins is a set the contains all of the built-in
+  # because builtins is a set that contains all of the built-in
   # functions (length, head, tail, filter, etc.). This saves
   # us from having to write, for example, "builtins.length"
   # instead of just "length".


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
