### PR TITLE
[scala/en] - clarify `return` keyword usage

### DIFF
--- a/scala.html.markdown
+++ b/scala.html.markdown
@@ -252,7 +252,7 @@ weirdSum(2, 4) // => 16
 // The return keyword exists in Scala, but it only returns from the inner-most
 // def that surrounds it.
 // WARNING: Using return in Scala is error-prone and should be avoided.
-// It has no effect on anonymous functions. For example:
+// It has no effect on anonymous functions. For example here you may expect foo(7) should return 17 but it returns 7:
 def foo(x: Int): Int = {
   val anonFunc: Int => Int = { z =>
     if (z > 5)
@@ -260,9 +260,10 @@ def foo(x: Int): Int = {
     else
       z + 2    // This line is the return value of anonFunc
   }
-  anonFunc(x)  // This line is the return value of foo
+  anonFunc(x) + 10  // This line is the return value of foo
 }
 
+foo(7) // => 7
 
 /////////////////////////////////////////////////
 // 3. Flow Control


### PR DESCRIPTION
Add an example to clarify that the `return` keyword only returns from the inner-most `def` that surrounds it not the output of the lambda function.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
 - [x] Yes, I have double-checked quotes and field names!
