### PR TITLE
Fixed duplicate vim entry and page language mismatch

### DIFF
--- a/el-gr/vim-gr.html.markdown
+++ b/el-gr/vim-gr.html.markdown
@@ -4,7 +4,7 @@ tool: vim
 contributors:
     - ["RadhikaG", "https://github.com/RadhikaG"]
 filename: LearnVim.txt
-land: el-gr
+lang: el-gr
 ---
 
 

--- a/el-gr/vim-gr.html.markdown
+++ b/el-gr/vim-gr.html.markdown
@@ -4,6 +4,7 @@ tool: vim
 contributors:
     - ["RadhikaG", "https://github.com/RadhikaG"]
 filename: LearnVim.txt
+land: el-gr
 ---
 
 


### PR DESCRIPTION
This refers to #3946 
I've not marked the title with `[language/lang-code]` so as to make clear it's a meta issue.

I built the project and can confirm this fixes the issue:

There's now only one vim entry:
![image](https://user-images.githubusercontent.com/22756345/83462090-b46b1400-a440-11ea-8d6b-c7f389b551b4.png)

and the `el-gr` button now exists.

Both `vim`  and `el-gr` now link to the right places.

And the language of the whole page now matches the selected(greek) langugage:
![image](https://user-images.githubusercontent.com/22756345/83462042-91d8fb00-a440-11ea-91e0-38525f03dc96.png)

