### PR TITLE
[RST/en] Fix compile errors from link and escaping

### DIFF
--- a/rst.html.markdown
+++ b/rst.html.markdown
@@ -49,9 +49,11 @@ Subtitles with dashes
 
 You can put text in *italic* or in **bold**, you can "mark" text as code with double backquote ``print()``.
 
+Special characters can be escaped using a backslash, e.g. \\ or \*.
+
 Lists are similar to Markdown, but a little more involved.
 
-Remember to line up list symbols (like - or *) with the left edge of the previous text block, and remember to use blank lines to separate new lists from parent lists:    
+Remember to line up list symbols (like - or \*) with the left edge of the previous text block, and remember to use blank lines to separate new lists from parent lists:    
 
 - First item
 - Second item
@@ -86,7 +88,7 @@ There are multiple ways to make links:
 - By typing a full comprehensible URL : https://github.com/ (will be automatically converted to a link)
 - By making a more Markdown-like link: `Github <https://github.com/>`_ .
 
-.. _Github https://github.com/
+.. _Github: https://github.com/
 
 ```
 


### PR DESCRIPTION
There were two issues here:

* The non-inline link was used incorrectly, and should have a colon after the specifier. 
* A compile error was generated from having a non-escaped `*`.

These can be verified by running `rst2html`:

```sh
$ rst2html.py ./restructuredtext.rst tmp.html
./restructuredtext.rst:24: (WARNING/2) Inline emphasis start-string without end-string.
./restructuredtext.rst:59: (WARNING/2) malformed hyperlink target.
```

After adding the colon and escape:

```sh
$ rst2html.py ./restructuredtext.rst tmp.html
```

I've also added a sentence on escaping.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
