### PR TITLE
[yaml/zh-cn] retranslate some content

### DIFF
--- a/zh-cn/yaml-cn.html.markdown
+++ b/zh-cn/yaml-cn.html.markdown
@@ -12,7 +12,7 @@ lang: zh-cn
 
 YAML 是一种数据序列化语言，旨在让人类直接可写可读。
 
-它是 JSON 的严格超集，增加了*在语法上有意义的*（syntactically significant）换行符和缩进，就像Python一样。但和Python的不同之处在于，YAML不允许使用*文字制表符*（literal tab characters）来表示缩进。
+它是 JSON 的严格超集，增加了*在语法上有意义的*（syntactically significant）换行符和缩进，就像 Python 一样。但和 Python 的不同之处在于，YAML 不允许使用*文字制表符*（literal tab characters）来表示缩进。
 
 
 ```yaml

--- a/zh-cn/yaml-cn.html.markdown
+++ b/zh-cn/yaml-cn.html.markdown
@@ -92,7 +92,7 @@ a_nested_map:
 : [ 2001-01-01, 2002-02-02 ]
 
 # 序列 (sequences，等价于列表 list 或数组 array ) 看起来像这样：
-# 注意 '-' 代表缩进：
+# 注意 '-' 也算缩进：
 a_sequence:
   - Item 1
   - Item 2

--- a/zh-cn/yaml-cn.html.markdown
+++ b/zh-cn/yaml-cn.html.markdown
@@ -12,7 +12,7 @@ lang: zh-cn
 
 YAML 是一种数据序列化语言，旨在让人类直接可写可读。
 
-它是 JSON 的严格超集，增加了*在语法上有意义的*（syntactically significant，参见译注1）换行符和缩进，就像Python一样。但和Python的不同之处在于，YAML不允许使用*文字制表符*（literal tab characters）来表示缩进。
+它是 JSON 的严格超集，增加了*在语法上有意义的*（syntactically significant）换行符和缩进，就像Python一样。但和Python的不同之处在于，YAML不允许使用*文字制表符*（literal tab characters）来表示缩进。
 
 
 ```yaml
@@ -41,12 +41,10 @@ however: 'A string, enclosed in quotes.'
 single quotes: 'have ''one'' escape pattern'
 double quotes: "have many: \", \0, \t, \u263A, \x0d\x0a == \r\n, and more."
 # UTF-8/16/32字符需要指明编码（通过\u）。
-# 参见译注2。
 Superscript two: \u00B2
 
 # 多行字符串既可以写成一个'字面量块'(使用 '|')，
 # 也可以写成一个'折叠块'(使用 '>')。
-# 参见译注3。
 literal_block: |
     This entire block of text will be the value of the 'literal_block' key,
     with line breaks being preserved.
@@ -128,7 +126,6 @@ base: &base
 
 # '<<'称为语言无关的合并键类型（Merge Key Language-Independent Type）.
 # 它表明一个或多个指定映射中的所有键值会插入到当前的映射中。
-# 参见译注4。
 
 foo: &foo
   <<: *base
@@ -188,22 +185,4 @@ set2:
 
 + [YAML official website](http://yaml.org/)
 + [Online YAML Validator](http://codebeautify.org/yaml-validator)
-
-### 译注
-
-1. 原文为'syntactically significant newlines and indentation'，原译为“语法显著换行符和缩进”。
-
-   个人认为，significant在此处应为“有意义的”，而非“显著的”。联系上下文，此处应指YAML的换行和缩进具有语法含义，而非在语法上显著（虽然确实很醒目）。
-
-   故译为“在语法上有意义的换行符和缩进”。
-
-2. 原文为'UTF-8/16/32 characters need to be encoded'，原译为“UTF-8/16/32 字符需要被转义”。个人认为，“转义”应为escape，并且虽然`\u`本身是一个转义字符，但目的是为了表明编码。
-
-   故译为“UTF-8/16/32字符需要指明编码”。
-
-3. “字面量块”即'literal block'，此处取literal的“字面”之意。
-
-   从下文也可以看到，字面量块会保留原字符串，包括换行等特殊字符；而折叠块会把原字符串的每一行用空格分隔，然后合并到同一行。
-
-4. 原文为'The regexp << is called Merge Key Language-Independent Type.'。若regexp直译为正则表达式，似有不妥，故在尽量保留含义的基础上有所省略。
 

--- a/zh-cn/yaml-cn.html.markdown
+++ b/zh-cn/yaml-cn.html.markdown
@@ -5,27 +5,27 @@ contributors:
 translators:
   - ["Zach Zhang", "https://github.com/checkcheckzz"]
   - ["Jiang Haiyun", "https://github.com/haiiiiiyun"]
+  - ["Wen Sun", "https://github.com/HermitSun"]
 filename: learnyaml-cn.yaml
 lang: zh-cn
 ---
 
-YAML 是一个数据序列化语言，被设计成人类直接可写可读的。
+YAML 是一种数据序列化语言，旨在让人类直接可写可读。
 
-它是 JSON 的严格超集，增加了语法显著换行符和缩进，就像 Python。但和 Python 不一样，
-YAML 根本不容许文字制表符。
+它是 JSON 的严格超集，增加了*在语法上有意义的*（syntactically significant，参见译注1）换行符和缩进，就像Python一样。但和Python的不同之处在于，YAML不允许使用*文字制表符*（literal tab characters）来表示缩进。
 
 
 ```yaml
 ---  # 文档开头
 
-# YAML 中的注解看起来像这样。
+# YAML 中的注释看起来像这样。
 
 ################
 # 标量类型     #
 ################
 
-# 我们的根对象 (它们在整个文件里延续) 将会是一个映射，
-# 它等价于在别的语言里的一个字典，哈希表或对象。
+# 我们的根对象 (贯穿整个文档的始终) 是一个映射（map），
+# 它等价于其它语言中的一个字典（dictionary），哈希表（hash）或对象（object）。
 key: value
 another_key: Another value goes here.
 a_number_value: 100
@@ -35,16 +35,18 @@ scientific_notation: 1e+12
 boolean: true
 null_value: null
 key with spaces: value
-# 注意，字符串不必被括在引号中，但也可以被括起来。
+# 注意，字符串可以不括在引号里。当然，也可以括在引号里。
 however: 'A string, enclosed in quotes.'
 'Keys can be quoted too.': "Useful if you want to put a ':' in your key."
 single quotes: 'have ''one'' escape pattern'
 double quotes: "have many: \", \0, \t, \u263A, \x0d\x0a == \r\n, and more."
-# UTF-8/16/32 字符需要被转义(encoded)
+# UTF-8/16/32字符需要指明编码（通过\u）。
+# 参见译注2。
 Superscript two: \u00B2
 
-# 多行字符串既可以写成像一个'文字块'(使用 |)，
-# 或像一个'折叠块'(使用 '>')。
+# 多行字符串既可以写成一个'字面量块'(使用 '|')，
+# 也可以写成一个'折叠块'(使用 '>')。
+# 参见译注3。
 literal_block: |
     This entire block of text will be the value of the 'literal_block' key,
     with line breaks being preserved.
@@ -67,7 +69,7 @@ folded_style: >
 # 集合类型         #
 ####################
 
-# 嵌套是通过缩进完成的。推荐使用 2 个空格的缩进（但非必须）
+# 嵌套是通过缩进完成的。推荐使用2个空格的缩进（但非必须）。
 a_nested_map:
   key: value
   another_key: Another Value
@@ -77,22 +79,22 @@ a_nested_map:
 # 映射的键不必是字符串。
 0.25: a float key
 
-# 键也可以是复合型的，比如多行对象
-# 我们用 ? 后跟一个空格来表示一个复合键的开始。
+# 键也可以是复合（complex）的，比如多行对象
+# 我们用'?'后跟一个空格来表示一个复合键的开始。
 ? |
   This is a key
   that has multiple lines
 : and this is its value
 
-# YAML 也允许使用复杂键语法表示序列间的映射关系。
-# 但有些语言的解析器可能会不支持。
+# YAML也允许使用复合键语法表示序列间的映射关系。
+# 但有些解析器可能会不支持。
 # 一个例子：
 ? - Manchester United
   - Real Madrid
 : [ 2001-01-01, 2002-02-02 ]
 
-# 序列 (等价于列表或数组) 看起来像这样：
-# 注意 '-' 算作缩进
+# 序列 (sequences，等价于列表list或数组array) 看起来像这样
+# 注意 '-' 代表缩进：
 a_sequence:
   - Item 1
   - Item 2
@@ -106,7 +108,7 @@ a_sequence:
   - - - Nested sequence indicators
       - can be collapsed
 
-# 因为 YAML 是 JSON 的超集，你也可以写 JSON 风格的映射和序列：
+# 因为YAML是JSON的超集，你也可以写JSON风格的映射和序列：
 json_map: {"key": "value"}
 json_seq: [3, 2, 1, "takeoff"]
 and quotes are optional: {key: [3, 2, 1, takeoff]}
@@ -115,7 +117,7 @@ and quotes are optional: {key: [3, 2, 1, takeoff]}
 # 其余的 YAML 特性    #
 #######################
 
-# YAML 还有一个方便的特性叫 '锚'，它能让你很容易在文档中进行文本复用。
+# YAML 还有一个方便的特性叫“锚”（anchors）。你可以使用它在文档中轻松地完成文本复用。
 # 如下两个键会有相同的值：
 anchored_content: &anchor_name This string will appear as the value of two keys.
 other_anchor: *anchor_name
@@ -124,8 +126,9 @@ other_anchor: *anchor_name
 base: &base
   name: Everyone has same name
 
-# The regexp << is called Merge Key Language-Independent Type.
-# 它表明指定映射的所有键值会插入到当前的映射中。
+# '<<'称为语言无关的合并键类型（Merge Key Language-Independent Type）.
+# 它表明一个或多个指定映射中的所有键值会插入到当前的映射中。
+# 参见译注4。
 
 foo: &foo
   <<: *base
@@ -137,42 +140,42 @@ bar: &bar
 
 # foo 和 bar 将都含有 name: Everyone has same name
 
-# YAML 还有标签，你可以用它显式地声明类型。
+# YAML 还有标签（tags），你可以用它显式地声明类型。
 explicit_string: !!str 0.5
-# 一些解析器实现特定语言的标签，就像这个针对 Python 的复数类型。
+# 一些解析器实现了特定语言的标签，就像这个针对Python的复数类型的标签。
 python_complex_number: !!python/complex 1+2j
 
-# 我们也可以在 YAML 的复合键中使用特定语言的标签
+# 我们也可以在YAML的复合键中使用特定语言的标签：
 ? !!python/tuple [5, 7]
 : Fifty Seven
-# 将会是 Python 中的  {(5, 7): 'Fifty Seven'}
+# 将会是Python中的 {(5, 7): 'Fifty Seven'}
 
 ####################
 # 其余的 YAML 类型 #
 ####################
 
-# 除了字符串和数字，YAML 还能理解其它标量。
-# ISO 格式的日期和日期时间文本也可以被解析。
+# 除了字符串和数字，YAML还支持其它标量。
+# ISO格式的日期和时间字面量也可以被解析。
 datetime: 2001-12-15T02:59:43.1Z
 datetime_with_spaces: 2001-12-14 21:59:43.10 -5
 date: 2002-12-14
 
 # 这个 !!binary 标签表明这个字符串实际上
-# 是一个用 base64 编码表示的二进制 blob。
+# 是一个用base64编码表示的二进制blob。
 gif_file: !!binary |
   R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5
   OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+
   +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC
   AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=
 
-# YAML 还有一个集合类型，它看起来像这样：
+# YAML还有一个集合（set）类型，它看起来像这样：
 set:
   ? item1
   ? item2
   ? item3
 or: {item1, item2, item3}
 
-# 集合只是值为 null 的映射；上面的集合等价于：
+# 集合只是值均为null的映射；上面的集合等价于：
 set2:
   item1: null
   item2: null
@@ -185,3 +188,22 @@ set2:
 
 + [YAML official website](http://yaml.org/)
 + [Online YAML Validator](http://codebeautify.org/yaml-validator)
+
+### 译注
+
+1. 原文为'syntactically significant newlines and indentation'，原译为“语法显著换行符和缩进”。
+
+   个人认为，significant在此处应为“有意义的”，而非“显著的”。联系上下文，此处应指YAML的换行和缩进具有语法含义，而非在语法上显著（虽然确实很醒目）。
+
+   故译为“在语法上有意义的换行符和缩进”。
+
+2. 原文为'UTF-8/16/32 characters need to be encoded'，原译为“UTF-8/16/32 字符需要被转义”。个人认为，“转义”应为escape，并且虽然`\u`本身是一个转义字符，但目的是为了表明编码。
+
+   故译为“UTF-8/16/32字符需要指明编码”。
+
+3. “字面量块”即'literal block'，此处取literal的“字面”之意。
+
+   从下文也可以看到，字面量块会保留原字符串，包括换行等特殊字符；而折叠块会把原字符串的每一行用空格分隔，然后合并到同一行。
+
+4. 原文为'The regexp << is called Merge Key Language-Independent Type.'。若regexp直译为正则表达式，似有不妥，故在尽量保留含义的基础上有所省略。
+

--- a/zh-cn/yaml-cn.html.markdown
+++ b/zh-cn/yaml-cn.html.markdown
@@ -67,7 +67,7 @@ folded_style: >
 # 集合类型         #
 ####################
 
-# 嵌套是通过缩进完成的。推荐使用2个空格的缩进（但非必须）。
+# 嵌套是通过缩进完成的。推荐使用 2 个空格的缩进（但非必须）。
 a_nested_map:
   key: value
   another_key: Another Value
@@ -78,20 +78,20 @@ a_nested_map:
 0.25: a float key
 
 # 键也可以是复合（complex）的，比如多行对象
-# 我们用'?'后跟一个空格来表示一个复合键的开始。
+# 我们用 '?' 后跟一个空格来表示一个复合键的开始。
 ? |
   This is a key
   that has multiple lines
 : and this is its value
 
-# YAML也允许使用复合键语法表示序列间的映射关系。
+# YAML 也允许使用复杂键语法表示序列间的映射关系。
 # 但有些解析器可能会不支持。
 # 一个例子：
 ? - Manchester United
   - Real Madrid
 : [ 2001-01-01, 2002-02-02 ]
 
-# 序列 (sequences，等价于列表list或数组array) 看起来像这样
+# 序列 (sequences，等价于列表 list 或数组 array ) 看起来像这样：
 # 注意 '-' 代表缩进：
 a_sequence:
   - Item 1
@@ -106,7 +106,7 @@ a_sequence:
   - - - Nested sequence indicators
       - can be collapsed
 
-# 因为YAML是JSON的超集，你也可以写JSON风格的映射和序列：
+# 因为 YAML 是 JSON 的超集，你也可以写 JSON 风格的映射和序列：
 json_map: {"key": "value"}
 json_seq: [3, 2, 1, "takeoff"]
 and quotes are optional: {key: [3, 2, 1, takeoff]}
@@ -142,37 +142,37 @@ explicit_string: !!str 0.5
 # 一些解析器实现了特定语言的标签，就像这个针对Python的复数类型的标签。
 python_complex_number: !!python/complex 1+2j
 
-# 我们也可以在YAML的复合键中使用特定语言的标签：
+# 我们也可以在 YAML 的复合键中使用特定语言的标签：
 ? !!python/tuple [5, 7]
 : Fifty Seven
-# 将会是Python中的 {(5, 7): 'Fifty Seven'}
+# 将会是 Python 中的 {(5, 7): 'Fifty Seven'}
 
 ####################
 # 其余的 YAML 类型 #
 ####################
 
-# 除了字符串和数字，YAML还支持其它标量。
-# ISO格式的日期和时间字面量也可以被解析。
+# 除了字符串和数字，YAML 还支持其它标量。
+# ISO 格式的日期和时间字面量也可以被解析。
 datetime: 2001-12-15T02:59:43.1Z
 datetime_with_spaces: 2001-12-14 21:59:43.10 -5
 date: 2002-12-14
 
 # 这个 !!binary 标签表明这个字符串实际上
-# 是一个用base64编码表示的二进制blob。
+# 是一个用 base64 编码表示的二进制 blob。
 gif_file: !!binary |
   R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5
   OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+
   +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC
   AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=
 
-# YAML还有一个集合（set）类型，它看起来像这样：
+# YAML 还有一个集合（set）类型，它看起来像这样：
 set:
   ? item1
   ? item2
   ? item3
 or: {item1, item2, item3}
 
-# 集合只是值均为null的映射；上面的集合等价于：
+# 集合只是值均为 null 的映射；上面的集合等价于：
 set2:
   item1: null
   item2: null
@@ -185,4 +185,3 @@ set2:
 
 + [YAML official website](http://yaml.org/)
 + [Online YAML Validator](http://codebeautify.org/yaml-validator)
-


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!

---

以下是译注，以供reviewer参考：

1. 原文为'syntactically significant newlines and indentation'，原译为“语法显著换行符和缩进”。
   个人认为，significant在此处应为“有意义的”，而非“显著的”。联系上下文，此处应指YAML的换行和缩进具有语法含义，而非在语法上显著（虽然确实很醒目）。
   故译为“在语法上有意义的换行符和缩进”。

2. 原文为'UTF-8/16/32 characters need to be encoded'，原译为“UTF-8/16/32 字符需要被转义”。个人认为，“转义”应为escape，并且虽然`\u`本身是一个转义字符，但目的是为了表明编码。
   故译为“UTF-8/16/32字符需要指明编码”。

3. “字面量块”即'literal block'，此处取literal的“字面”之意。
   从下文也可以看到，字面量块会保留原字符串，包括换行等特殊字符；而折叠块会把原字符串的每一行用空格分隔，然后合并到同一行。

4. 原文为'The regexp << is called Merge Key Language-Independent Type.'。若regexp直译为正则表达式，似有不妥，故在尽量保留含义的基础上有所省略。