### PR TITLE
[python/en] improved demo of `if` expression

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -186,7 +186,7 @@ some_unknown_var  # Raises a NameError
 
 # if can be used as an expression
 # Equivalent of C's '?:' ternary operator
-"yahoo!" if 3 > 2 else 2  # => "yahoo!"
+"yay!" if 0 > 1 else "nay!"  # => "nay!"
 
 # Lists store sequences
 li = []


### PR DESCRIPTION
- [x] I solemnly swear that this is all ~~original~~ improved content of which I am **not** the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] ~~If you've~~ I have not changed any part of the YAML Frontmatter, ~~make sure~~ thus, it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
***
the existing page has a demo for `if` expressions that :
 - returns a string when expression resolves to `True`
 - returns a number when expression resolves to `False`

this reduces readability and looks ambiguous
i propose that both resolutions return strings which are contradictory in their meaning – *yay* and *nay*
