### PR TITLE
[qsharp/en] Remove mention of multi-line comments

### DIFF
--- a/qsharp.html.markdown
+++ b/qsharp.html.markdown
@@ -9,20 +9,9 @@ filename: LearnQSharp.qs
 
 Q# is a high-level domain-specific language which enables developers to write quantum algorithms. Q# programs can be executed on a quantum simulator running on a classical computer and (in future) on quantum computers.
 
-This is the new outline
-
 ```C#
 // Single-line comments start with //
 
-/*
-/
-Multi-line comments
-like so
-\
-*/
-
-// Note: Using C# multi-line around Q# 
-// there doesn't appear to be a Q# markdown formatter yet.
 
 /////////////////////////////////////
 // 1. Quantum data types and operators


### PR DESCRIPTION
Q# does not support multi-line comments, so that mention can be misleading.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
