### PR TITLE
[pascal/ru][homepage] added (human) lang to pascal-ru

### DIFF
--- a/ru-ru/pascal-ru.html.markdown
+++ b/ru-ru/pascal-ru.html.markdown
@@ -6,6 +6,7 @@ contributors:
     - ["Keith Miyake", "https://github.com/kaymmm"]
 translators:
     - ["Anton 'Dart' Nikolaev", "https://github.com/dartfnm"]
+lang: ru-ru
 ---
 
 


### PR DESCRIPTION
- [x] I solemnly swear that this is all ~original~ improved content of which I am **not** the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've I have not changed any part of the YAML Frontmatter, make sure thus it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
---
### resolves #3956 
fixes doubled entry for Pascal on homepage
added the human language code in the YAML Frontmatter of [Pascal-ru][1]

[1]: https://github.com/adambard/learnxinyminutes-docs/blob/master/ru-ru/pascal-ru.html.markdown