### PR TITLE
[vim/de] fix syntax on yaml frontmatter

### DIFF
--- a/de-de/vim-de.html.markdown
+++ b/de-de/vim-de.html.markdown
@@ -1,7 +1,7 @@
 ---
 category: tool
 tool: vim
-lang = de-de
+lang: de-de
 contributors:
     - ["RadhikaG", "https://github.com/RadhikaG"]
 translators:


### PR DESCRIPTION
the yaml syntax is broken at line 4
possible reason for CI test fail
possibly fixes #4000 
***
- [x] I solemnly swear that this is all ~~original~~ improved content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
