### PR TITLE
[COBOL] Typo in cobol tutorial : DIVSION -> DIVISION

### DIFF
--- a/cobol.html.markdown
+++ b/cobol.html.markdown
@@ -29,7 +29,7 @@ organizations.
       
       *COBOL code is broken up into 4 divisions.
       *Those divisions, in order, are:
-      *IDENTIFICATION DIVSION.
+      *IDENTIFICATION DIVISION.
       *ENVIRONMENT DIVISION.
       *DATA DIVISION.
       *PROCEDURE DIVISION.
@@ -75,7 +75,7 @@ organizations.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 THE-MESSAGE      PIC X(20).
-      PROCEDURE DIVSION.
+      PROCEDURE DIVISION.
           DISPLAY "STARTING PROGRAM".
           MOVE "HELLO WORLD" TO THE-MESSAGE.
           DISPLAY THE-MESSAGE.


### PR DESCRIPTION
See https://duckduckgo.com/?t=canonical&q=IDENTIFICATION+DIVSION+COBOL&ia=web

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
- [x] Yes, I have double-checked quotes and field names!
