### PR TITLE
[set-theory/en] Correction: Cardinality of an empty set is 0

### DIFF
--- a/set-theory.html.markdown
+++ b/set-theory.html.markdown
@@ -44,7 +44,7 @@ For example, if `S = { 1, 2, 4 }`, then `|S| = 3`.
 * The empty set can be constructed in set builder notation using impossible conditions, e.g. `∅ = { x : x =/= x }`, or `∅ = { x : x ∈ N, x < 0 }`;
 * the empty set is always unique (i.e. there is one and only one empty set);
 * the empty set is a subset of all sets;
-* the cardinality of the empty set is 1, i.e. `|∅| = 1`.
+* the cardinality of the empty set is 0, i.e. `|∅| = 0`.
 
 ## Representing sets
 


### PR DESCRIPTION
Citations:
- JMoravitz (https://math.stackexchange.com/users/179297/jmoravitz), What is the cardinality of the set of the empty set?, URL (version: 2016-01-13): https://math.stackexchange.com/q/1610231
- Wikipedia contributors. (2020, September 25). Empty set. In Wikipedia, The Free Encyclopedia. Retrieved 06:50, September 29, 2020, from https://en.wikipedia.org/w/index.php?title=Empty_set&oldid=980302053

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
