### PR TITLE
[xml/en] copy edit and fix code typo

### DIFF
--- a/xml.html.markdown
+++ b/xml.html.markdown
@@ -100,8 +100,9 @@ This is what makes XML versatile. It is human readable too. The following docume
 
 A XML document is *well-formed* if it is syntactically correct. However, it is possible to add more constraints to the document, using Document Type Definitions (DTDs). A document whose elements are attributes are declared in a DTD and which follows the grammar specified in that DTD is called *valid* with respect to that DTD, in addition to being well-formed.
 
+Declaring a DTD externally:
+
 ```xml
-<!-- Declaring a DTD externally: -->
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE bookstore SYSTEM "Bookstore.dtd">
 <!-- Declares that bookstore is our root element and 'Bookstore.dtd' is the path
@@ -114,8 +115,11 @@ A XML document is *well-formed* if it is syntactically correct. However, it is p
     <price>30.00</price>
   </book>
 </bookstore>
+```
 
-<!-- The DTD file: -->
+The DTD file (Bookstore.dtd):
+
+```
 <!ELEMENT bookstore (book+)>
 <!-- The bookstore element may contain one or more child book elements. -->
 <!ELEMENT book (title, price)>
@@ -128,10 +132,11 @@ A XML document is *well-formed* if it is syntactically correct. However, it is p
   only contain text which is read by the parser and must not contain children.
   Compare with CDATA, or character data. -->
 <!ELEMENT price (#PCDATA)>
-]>
+```
 
-<!-- The DTD could be declared inside the XML file itself.-->
+The DTD could be declared inside the XML file itself:
 
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE bookstore [


### PR DESCRIPTION
under well-formedness and validation, the first line of comment within code blocks (line 104, 118, 133) should be written as text paragraph instead, otherwise anyone who simply copy-paste the code will not be able to preview the result, the original code block is now separated into three parts, each preceded by a single line of text paragraph for clarity, also the external dtd file had a typo in last commit (60a1a43) that should have been removed at the end (line 131)

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
