### PR TITLE
[python/en] adding an example for closures in python where we use the `nonlocal` …

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -635,6 +635,21 @@ def create_adder(x):
 add_10 = create_adder(10)
 add_10(3)   # => 13
 
+# Closures in nested functions, the nonlocal keyword to work with variables in nested scope which shouldn't be in the inner functions.
+def create_avg():
+    total = 0
+    count = 0
+    def avg(n):
+        nonlocal total, count
+        total += n
+        count += 1
+        return total/count
+    return avg
+avg = create_avg()
+avg(3) # => 3.0
+avg(5) # (3+5)/2 => 4.0
+avg(7) # (8+7)/2 => 5.0
+
 # There are also anonymous functions
 (lambda x: x > 2)(3)                  # => True
 (lambda x, y: x ** 2 + y ** 2)(2, 1)  # => 5

--- a/python.html.markdown
+++ b/python.html.markdown
@@ -635,7 +635,8 @@ def create_adder(x):
 add_10 = create_adder(10)
 add_10(3)   # => 13
 
-# Closures in nested functions, the nonlocal keyword to work with variables in nested scope which shouldn't be in the inner functions.
+# Closures in nested functions:
+# We can use the nonlocal keyword to work with variables in nested scope which shouldn't be declared in the inner functions.
 def create_avg():
     total = 0
     count = 0


### PR DESCRIPTION
…keyword

Adding an example for the case of nested functions with closure scopes, when we use the python 3s keyword 'nonlocal' to point to the variables in the outer functions

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
