### PR TITLE
Add a short note about `final` keyword

### DIFF
--- a/swift.html.markdown
+++ b/swift.html.markdown
@@ -822,6 +822,17 @@ for _ in 0..<10 {
  See more here: https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html
  */
 
+// MARK: Preventing Overrides
+
+// You can add keyword `final` before a class or instance method, or a property to prevent it from being overridden
+class Shape {
+    final var finalInteger = 10
+}
+
+// Prevent a class from being subclassed
+final class ViewManager {
+}
+
 // MARK: Conditional Compilation, Compile-Time Diagnostics, & Availability Conditions
 
 // Conditional Compilation


### PR DESCRIPTION
It's a general good practice to mark classes as `final` unless they are designed to be subclassed.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
