### PR TITLE
Update last exercise

### DIFF
--- a/elisp.html.markdown
+++ b/elisp.html.markdown
@@ -306,7 +306,7 @@ filename: learn-emacs-lisp.el
 (defun boldify-names ()
     (switch-to-buffer-other-window "*test*")
     (goto-char (point-min))
-    (while (re-search-forward "Bonjour \\(.+\\)!" nil t)
+    (while (re-search-forward "Bonjour \\(.+\\)" nil t)
       (add-text-properties (match-beginning 1)
                            (match-end 1)
                            (list 'face 'bold)))
@@ -321,8 +321,6 @@ filename: learn-emacs-lisp.el
 ;; a group of            | this is the \\( ... \\) construct
 ;;   any character       | this is the .
 ;;   possibly repeated   | this is the +
-;; and the "!" string.
-
 ;; Ready?  Test it!
 
 (boldify-names)


### PR DESCRIPTION
In the last example, the regular expression is incorrect because it looks for a string with a bang symbol at the end.
None of the names in the list matches so it fails but the error message is supressed so that would confuser users of the file.

- [X} I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]`
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
