### PR TITLE
[EN/Clojure] Fix the as-> macro exemple

### DIFF
--- a/clojure.html.markdown
+++ b/clojure.html.markdown
@@ -298,8 +298,8 @@ keymap ; => {:a 1, :b 2, :c 3}
 (as-> [1 2 3] input
   (map inc input);=> You can use last transform's output at the last position
   (nth input 2) ;=>  and at the second position, in the same expression
-  (conj [4 5 6] input [8 9 10])) ;=> or in the middle !
-
+  (conj [4 5 6] input 8 9 10)) ;=> or in the middle !
+                               ; Result: [4 5 6 4 8 9 10]
 
 
 ; Modules


### PR DESCRIPTION
I wanted to show the result of the exemple on the -> macro but I changed it a bit to show this instead:

```clojure
user=> (as-> [1 2 3] input
  #_=>   (map inc input);=> You can use last transform's output at the last position
  #_=>   (nth input 2) ;=>  and at the second position, in the same expression
  #_=>   (conj [4 5 6] input 8 9 10))
[4 5 6 4 8 9 10]
```
The old version was:

```clojure
user=> (as-> [1 2 3] input
  #_=>   (map inc input);=> You can use last transform's output at the last position
  #_=>   (nth input 2) ;=>  and at the second position, in the same expression
  #_=>   (conj [4 5 6] input [8 9 10]))
[4 5 6 4 [8 9 10]]
```
I am not sure if it was intentional.

- [ x] I solemnly swear that this is all original content of which I am the original author
- [x ] Pull request title is prepended with `[language/lang-code]`
- [x ] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ x] Yes, I have double-checked quotes and field names!
