### PR TITLE
[toml/en] hex, octal and binary are valid integer formats

### DIFF
--- a/toml.html.markdown
+++ b/toml.html.markdown
@@ -69,11 +69,15 @@ The first newline is trimmed in raw strings.
 ###########
 
 ## Integers can start with a +, a - or nothing.
-## Leading zeros are not allowed. Hex, octal, and binary forms are not allowed.
+## Leading zeros are not allowed.
+## Hex, octal, and binary forms are allowed.
 ## Values that cannot be expressed as a series of digits are not allowed.
 int1 = +42
 int2 = 0
 int3 = -21
+int4 = 0xdeadbeef
+int5 = 0o755
+int6 = 0b11011100
 integerRange = 64
 
 ## You can use underscores to enhance readability. Each


### PR DESCRIPTION
Update the integer section to reflect the fact that hex, octal and binary representations are allowed in toml.

They were added to toml in version 0.5 and more work has to be done to update this document to that version, as mentioned here:
https://github.com/adambard/learnxinyminutes-docs/issues/3158

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
