### PR TITLE
[c/en] Correct information about `sizeof`

### DIFF
--- a/c.html.markdown
+++ b/c.html.markdown
@@ -131,7 +131,7 @@ int main (int argc, char** argv)
   printf("%zu\n", sizeof(int)); // => 4 (on most machines with 4-byte words)
 
   // If the argument of the `sizeof` operator is an expression, then its argument
-  // is not evaluated (except VLAs (see below)).
+  // is not evaluated (except arrays (see below)).
   // The value it yields in this case is a compile-time constant.
   int a = 1;
   // size_t is an unsigned integer type of at least 2 bytes used to represent


### PR DESCRIPTION
Correct information about "`sizeof` only evaluating an expression if it's a VLA."
When trying this, it seems that `sizeof` would evaluate even arrays of constant known sizes, not just VLAs:

```c
int size = 42;
int array1[size];
int array2[42];

printf("%zu\n", sizeof(array1)); // => 168
printf("%zu\n", sizeof(array2)); // => 168
```

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
