### PR TITLE
[COBOL/en] Fix typo in the data item definition

### DIFF
--- a/cobol.html.markdown
+++ b/cobol.html.markdown
@@ -44,7 +44,7 @@ organizations.
 
       *Let's declare some variables.
       *We do this in the WORKING-STORAGE section within the DATA DIVISION.
-      *Each data item (aka variable) with start with a level number, 
+      *Each data item (aka variable) starts with a level number, 
       *then the name of the item, followed by a picture clause 
       *describing the type of data that the variable will contain.
       *Almost every COBOL programmer will abbreviate PICTURE as PIC.


### PR DESCRIPTION
Change "with start with a level number" to "starts with a level number"

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
