### PR TITLE
[scala/en] typo in creation of a new object

### DIFF
--- a/scala.html.markdown
+++ b/scala.html.markdown
@@ -481,7 +481,7 @@ class SaintBernard extends Dog {
 	def bite = false
 }  
 
-scala> b  
+scala> val b = new SaintBernard
 res0: SaintBernard = SaintBernard@3e57cd70  
 scala> b.breed  
 res1: String = Saint Bernard  


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- I only speak English and French, and the page for [scala/fr] is less complete that the one in English, without this typo. I'll try to extend it, but later.
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
