### PR TITLE
Remove binary gender example from R

### DIFF
--- a/r.html.markdown
+++ b/r.html.markdown
@@ -255,16 +255,16 @@ c('Z', 'o', 'r', 'r', 'o') == "Z" # TRUE FALSE FALSE FALSE FALSE
 
 # FACTORS
 # The factor class is for categorical data
-# Factors can be ordered (like childrens' grade levels) or unordered (like gender)
-factor(c("female", "female", "male", NA, "female"))
-#  female female male   <NA>   female
-# Levels: female male
+# Factors can be ordered (like childrens' grade levels) or unordered (like colors)
+factor(c("blue", "blue", "green", NA, "blue"))
+#  blue blue green   <NA>   blue
+# Levels: blue green
 # The "levels" are the values the categorical data can take
 # Note that missing data does not enter the levels
-levels(factor(c("male", "male", "female", NA, "female"))) # "female" "male"
+levels(factor(c("green", "green", "blue", NA, "blue"))) # "blue" "green"
 # If a factor vector has length 1, its levels will have length 1, too
-length(factor("male")) # 1
-length(levels(factor("male"))) # 1
+length(factor("green")) # 1
+length(levels(factor("green"))) # 1
 # Factors are commonly seen in data frames, a data structure we will cover later
 data(infert) # "Infertility after Spontaneous and Induced Abortion"
 levels(infert$education) # "0-5yrs"  "6-11yrs" "12+ yrs"


### PR DESCRIPTION
To whoever is reviewing this - I don't know your views on gender, but I think this change should be made because it makes life better for some people at zero cost to others. Our society is drenched in references to binary gender, and that causes pain for a lot of lgbtq people. Changing this example to something other than gender makes reading this document a painless experience for everyone, and might actually avoid convincing someone they don't belong in tech :)

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!