### PR TITLE
nix-lang: Remove a redundant `builtins.`

### DIFF
--- a/nix.html.markdown
+++ b/nix.html.markdown
@@ -355,7 +355,7 @@ with builtins; [
   # its contents. You can read files from anywhere. In this example,
   # we write a file into the store, and then read it back out.
   (let filename = toFile "foo.txt" "hello!"; in
-    [filename (builtins.readFile filename)])
+    [filename (readFile filename)])
   #=> [ "/nix/store/ayh05aay2anx135prqp0cy34h891247x-foo.txt" "hello!" ]
 
   # We can also download files into the Nix store.


### PR DESCRIPTION
This `builtins.` name spacing here can go. Either also have it before `toFile`, or don't have it before `toFile` and `readFile`. Since we have `with builtins; [` at the very beginning of the docs, this can be safely removed.

- [x] I solemnly swear that this is all original content of which I am the original author
- [ ] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
