### PR TITLE
[go/zh-cn] Remove negative and inaccurate translation

### DIFF
--- a/zh-cn/go-cn.html.markdown
+++ b/zh-cn/go-cn.html.markdown
@@ -40,7 +40,7 @@ import (
 func main() {
     // 往标准输出打印一行。
     // 用包名fmt限制打印函数。
-    fmt.Println("天坑欢迎你!")
+    fmt.Println("你好世界")
 
     // 调用当前包的另一个函数。
     beyondHello()


### PR DESCRIPTION
The original words is "hello world", the "你好世界" is the accurate and direct translation of it, see the Chinses version `hello_world` page of wikipedia: https://zh.wikipedia.org/wiki/Hello_World

The old "天坑欢迎你!" means "welcome to this big hole", and have negative meanings in Chinese slang. I think it's meaning should be "welcome to using this big fxxking shxt".

@vendethiel 