### PR TITLE
[kotlin/en] fooData was mistaken for fooCopy in a comment

### DIFF
--- a/kotlin.html.markdown
+++ b/kotlin.html.markdown
@@ -180,7 +180,7 @@ fun helloWorld(val name : String) {
 
     // destructuring in "for" loop
     for ((a, b, c) in listOf(fooData)) {
-        println("$a $b $c") // => 1 100 4
+        println("$a $b $c") // => 1 2 4
     }
 
     val mapData = mapOf("a" to 1, "b" to 2)


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)

This is just a tiny issue: the values of fooCopy -- `1 100 4` -- were used instead of fooData's on line 183.