### PR TITLE
[set-theory/en] use not equal ASCII symbol

### DIFF
--- a/set-theory.html.markdown
+++ b/set-theory.html.markdown
@@ -41,7 +41,7 @@ The cardinality, or size, of a set is determined by the number of items in the s
 For example, if `S = { 1, 2, 4 }`, then `|S| = 3`.
 
 ### The Empty Set
-* The empty set can be constructed in set builder notation using impossible conditions, e.g. `∅ = { x : x =/= x }`, or `∅ = { x : x ∈ N, x < 0 }`;
+* The empty set can be constructed in set builder notation using impossible conditions, e.g. `∅ = { x : x ≠ x }`, or `∅ = { x : x ∈ N, x < 0 }`;
 * the empty set is always unique (i.e. there is one and only one empty set);
 * the empty set is a subset of all sets;
 * the cardinality of the empty set is 0, i.e. `|∅| = 0`.


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
