### PR TITLE
[multiple] Move Frameworks and Libraries to "Frameworks and Libraries" section.

### DIFF
--- a/angularjs.html.markdown
+++ b/angularjs.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: AngularJS
+category: framework
+framework: AngularJS
 contributors:
     - ["Walter Cordero", "http://waltercordero.com"]
 filename: learnangular.html

--- a/de-de/opencv-de.html.markdown
+++ b/de-de/opencv-de.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: OpenCV
+category: framework
+framework: OpenCV
 filename: learnopencv-de.py
 contributors:
     - ["Yogesh Ojha", "http://github.com/yogeshojha"]

--- a/de-de/pyqt-de.html.markdown
+++ b/de-de/pyqt-de.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: PyQT
+category: framework
+framework: PyQT
 filename: learnpyqt-de.py
 contributors:
     - ["Nathan Hughes", "https://github.com/sirsharpest"]

--- a/de-de/qt-de.html.markdown
+++ b/de-de/qt-de.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: Qt Framework
+category: framework
+framework: Qt Framework
 language: C++
 filename: learnqt-de.cpp
 contributors:

--- a/de-de/shutit-de.html.markdown
+++ b/de-de/shutit-de.html.markdown
@@ -1,7 +1,7 @@
 ---
-category: tool
+category: framework
 filename: learnshutit-de.html
-tool: ShutIt
+framework: ShutIt
 contributors:
     - ["Ian Miell", "http://ian.meirionconsulting.tk"]
 translators:

--- a/directx9.html.markdown
+++ b/directx9.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: DirectX 9
+category: framework
+framework: DirectX 9
 filename: learndirectx9.cpp
 contributors:
     - ["Simon Deitermann", "s.f.deitermann@t-online.de"]

--- a/es-es/jquery-es.html.markdown
+++ b/es-es/jquery-es.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: jquery
+category: framework
+framework: jquery
 contributors:
     - ["Sawyer Charles", "https://github.com/xssc"]
 translators:

--- a/es-es/pyqt-es.html.markdown
+++ b/es-es/pyqt-es.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: PyQT
+category: framework
+framework: PyQT
 filename: learnpyqt-es.py
 contributors:
     - ["Nathan Hughes", "https://github.com/sirsharpest"]

--- a/es-es/pythonstatcomp-es.html.markdown
+++ b/es-es/pythonstatcomp-es.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: Statistical Computing with Python
+category: framework
+framework: Statistical Computing with Python
 contributors:
     - ["e99n09", "https://github.com/e99n09"]
 filename: pythonstatcomp-es.py

--- a/fr-fr/jquery-fr.html.markdown
+++ b/fr-fr/jquery-fr.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: jquery
+category: framework
+framework: jquery
 contributors:
     - ["Sawyer Charles", "https://github.com/xssc"]
 translators:

--- a/fr-fr/pyqt-fr.html.markdown
+++ b/fr-fr/pyqt-fr.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: PyQT
+category: framework
+framework: PyQT
 filename: learnpyqt-fr.py
 contributors:
     - ["Nathan Hughes", "https://github.com/sirsharpest"]

--- a/id-id/pyqt-id.html.markdown
+++ b/id-id/pyqt-id.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: PyQt
+category: framework
+framework: PyQt
 language: Python
 filename: learnqt-id.py
 contributors:

--- a/it-it/jquery-it.html.markdown
+++ b/it-it/jquery-it.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: jquery
+category: framework
+framework: jquery
 contributors:
     - ["Sawyer Charles", "https://github.com/xssc"]
 filename: jquery-it.js

--- a/it-it/pyqt-it.html.markdown
+++ b/it-it/pyqt-it.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: PyQT
+category: framework
+framework: PyQT
 filename: learnpyqt-it.py
 contributors:
     - ["Nathan Hughes", "https://github.com/sirsharpest"]

--- a/it-it/qt-it.html.markdown
+++ b/it-it/qt-it.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: Qt Framework
+category: framework
+framework: Qt Framework
 language: C++
 filename: learnqt-it.cpp
 contributors:

--- a/jquery.html.markdown
+++ b/jquery.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: jquery
+category: framework
+framework: jquery
 contributors:
     - ["Sawyer Charles", "https://github.com/xssc"]
     - ["Devansh Patil", "https://github.com/subtra3t"]

--- a/messagepack.html.markdown
+++ b/messagepack.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: messagepack
+category: framework
+framework: messagepack
 filename: learnmessagepack.mpac
 contributors:
   - ["Gabriel Chuan", "https://github.com/gczh"]

--- a/opencv.html.markdown
+++ b/opencv.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: OpenCV
+category: framework
+framework: OpenCV
 filename: learnopencv.py
 contributors:
     - ["Yogesh Ojha", "http://github.com/yogeshojha"]

--- a/opengl.html.markdown
+++ b/opengl.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: OpenGL
+category: framework
+framework: OpenGL
 filename: learnopengl.cpp
 contributors:
     - ["Simon Deitermann", "s.f.deitermann@t-online.de"]

--- a/p5.html.markdown
+++ b/p5.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: p5
+category: framework
+framework: p5
 contributors:
     - ['Amey Bhavsar', 'https://github.com/ameybhavsar24']
     - ['Claudio Busatto', 'https://github.com/cjcbusatto']

--- a/pt-br/jquery-pt.html.markdown
+++ b/pt-br/jquery-pt.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: jquery
+category: framework
+framework: jquery
 contributors:
     - ["Sawyer Charles", "https://github.com/xssc"]
 translators:

--- a/pt-br/pyqt-pt.html.markdown
+++ b/pt-br/pyqt-pt.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: PyQT
+category: framework
+framework: PyQT
 filename: learnpyqt-pt.py
 contributors:
     - ["Nathan Hughes", "https://github.com/sirsharpest"]

--- a/pt-br/pythonstatcomp-pt.html.markdown
+++ b/pt-br/pythonstatcomp-pt.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: Statistical Computing with Python
+category: framework
+framework: Statistical Computing with Python
 contributors:
     - ["e99n09", "https://github.com/e99n09"]
 translators:

--- a/pt-br/qt-pt.html.markdown
+++ b/pt-br/qt-pt.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: Qt Framework
+category: framework
+framework: Qt Framework
 language: C++
 filename: learnqt-pt.cpp
 contributors:

--- a/pyqt.html.markdown
+++ b/pyqt.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: PyQT
+category: framework
+framework: PyQT
 filename: learnpyqt.py
 contributors:
     - ["Nathan Hughes", "https://github.com/sirsharpest"]

--- a/pythonstatcomp.html.markdown
+++ b/pythonstatcomp.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: Statistical Computing with Python
+category: framework
+framework: Statistical Computing with Python
 contributors:
     - ["e99n09", "https://github.com/e99n09"]
 ---

--- a/qt.html.markdown
+++ b/qt.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: Qt Framework
+category: framework
+framework: Qt Framework
 language: c++
 filename: learnqt.cpp
 contributors:

--- a/raylib.html.markdown
+++ b/raylib.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: raylib
+category: framework
+framework: raylib
 filename: learnraylib.c
 contributors:
     - ["Nikolas Wipper", "https://notnik.cc"]

--- a/ru-ru/jquery-ru.html.markdown
+++ b/ru-ru/jquery-ru.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: jquery
+category: framework
+framework: jquery
 contributors:
     - ["Sawyer Charles", "https://github.com/xssc"]
 translators:

--- a/ru-ru/pyqt-ru.html.markdown
+++ b/ru-ru/pyqt-ru.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: PyQT
+category: framework
+framework: PyQT
 lang: ru-ru
 filename: learnpyqt-ru.py
 contributors:

--- a/ru-ru/qt-ru.html.markdown
+++ b/ru-ru/qt-ru.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: Qt Framework
+category: framework
+framework: Qt Framework
 language: C++
 filename: learnqt-ru.cpp
 contributors:

--- a/shutit.html.markdown
+++ b/shutit.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: ShutIt
+category: framework
+framework: ShutIt
 contributors:
     - ["Ian Miell", "http://ian.meirionconsulting.tk"]
 filename: learnshutit.html

--- a/tr-tr/jquery-tr.html.markdown
+++ b/tr-tr/jquery-tr.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: jquery
+category: framework
+framework: jquery
 contributors:
     - ["Seçkin KÜKRER", "https://github.com/leavenha"]
 filename: jquery-tr-tr.js

--- a/zh-cn/angularjs-cn.html.markdown
+++ b/zh-cn/angularjs-cn.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: AngularJS
+category: framework
+framework: AngularJS
 contributors:
     - ["Walter Cordero", "http://waltercordero.com"]
 filename: learnangular-cn.html

--- a/zh-cn/jquery-cn.html.markdown
+++ b/zh-cn/jquery-cn.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: jquery
+category: framework
+framework: jquery
 contributors:
     - ["Sawyer Charles", "https://github.com/xssc"]
 translators:

--- a/zh-cn/opencv-cn.html.markdown
+++ b/zh-cn/opencv-cn.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: OpenCV
+category: framework
+framework: OpenCV
 filename: learnopencv.py
 contributors:
     - ["Yogesh Ojha", "http://github.com/yogeshojha"]

--- a/zh-cn/pyqt-cn.html.markdown
+++ b/zh-cn/pyqt-cn.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: PyQT
+category: framework
+framework: PyQT
 filename: learnpyqt.py
 contributors:
     - ["Nathan Hughes", "https://github.com/sirsharpest"]

--- a/zh-cn/raylib-cn.html.markdown
+++ b/zh-cn/raylib-cn.html.markdown
@@ -1,6 +1,6 @@
 ---
-category: tool
-tool: raylib
+category: framework
+framework: raylib
 lang: zh-cn
 filename: learnraylib-cn.c
 contributors:


### PR DESCRIPTION
In [another PR](https://github.com/adambard/learnxinyminutes-site/pull/83) I am adding support for a "Frameworks and Libraries" section.  This will help the community find docs on frameworks and libraries, and also encourage the community to document more frameworks.

In this PR, I am moving existing frameworks over to the "Frameworks and Libraries" section. Eventually, I hope many more frameworks like React, Express, Django, etc. will be created and added to Frameworks.

This is a small, but important change. I think it will really help direct the community to document more frameworks on learn x in y, which would be very helpful to developers.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!

Before:
![before](https://user-images.githubusercontent.com/74446843/110576732-1a926f00-8116-11eb-9c71-889b37ead8ef.png)

After:
![after](https://user-images.githubusercontent.com/74446843/110576734-1ebe8c80-8116-11eb-9bc5-cfc2c391af56.png)
