### PR TITLE
[nix/de-de] Unify Further Reading Links

### DIFF
--- a/de-de/nix-de.html.markdown
+++ b/de-de/nix-de.html.markdown
@@ -356,3 +356,6 @@ with builtins; [
 
 * [Susan Potter - Nix Cookbook - Nix By Example]
   (https://ops.functionalalgebra.com/nix-by-example/)
+  
+* [Rommel Martinez - A Gentle Introduction to the Nix Family]
+  (https://web.archive.org/web/20210121042658/https://ebzzry.io/en/nix/#nix)


### PR DESCRIPTION
Unify further reading references.
Nix Manuel, Fisher example, Potter Cookbook, and Martinez Intro.
All live links.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
