### PR TITLE
[c#/en] Fix typo in C# doc

### DIFF
--- a/csharp.html.markdown
+++ b/csharp.html.markdown
@@ -851,7 +851,7 @@ on a new line! ""Wow!"", the masses cried";
         }
 
         // It's also possible to define custom Indexers on objects.
-        // All though this is not entirely useful in this example, you
+        // Although this is not entirely useful in this example, you
         // could do bicycle[0] which returns "chris" to get the first passenger or
         // bicycle[1] = "lisa" to set the passenger. (of this apparent quattrocycle)
         private string[] passengers = { "chris", "phil", "darren", "regina" };

--- a/pt-br/csharp-pt.html.markdown
+++ b/pt-br/csharp-pt.html.markdown
@@ -749,7 +749,7 @@ on a new line! ""Wow!"", the masses cried";
         }
 
         // It's also possible to define custom Indexers on objects.
-        // All though this is not entirely useful in this example, you
+        // Although this is not entirely useful in this example, you
         // could do bicycle[0] which yields "chris" to get the first passenger or
         // bicycle[1] = "lisa" to set the passenger. (of this apparent quattrocycle)
         private string[] passengers = { "chris", "phil", "darren", "regina" };


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
