### PR TITLE
[chicken/en]: adapt to CHICKEN 5

### DIFF
--- a/CHICKEN.html.markdown
+++ b/CHICKEN.html.markdown
@@ -362,8 +362,6 @@ sqr                        ;; => #<procedure (sqr x)>
 ;; The CHICKEN core is very minimal, but additional features are provided by library extensions known as Eggs.
 ;; You can install Eggs with 'chicken-install <eggname>' command.
 
-;; 'numbers' egg provides support for full numeric tower.
-(require-extension numbers)
 ;; complex numbers
 3+4i                               ;; => 3+2i
 ;; Supports fractions without falling back to inexact flonums
@@ -375,12 +373,12 @@ sqr                        ;; => #<procedure (sqr x)>
 (numerator 2/3)                    ;; => 2
 
 ;; 'utf8' provides unicode support
-(require-extension utf8)
+(import utf8)
 "\u03BBx:(\u03BC\u0251.\u0251\u2192\u0251).xx" ;; => "λx:(μɑ.ɑ→ɑ).xx"
 
 ;; 'posix' provides file I/O and lots of other services for unix-like operating systems
 ;; Some of the functions are not available in Windows system,
-;; See http://wiki.call-cc.org/man/4/Unit%20posix for more details
+;; See http://wiki.call-cc.org/man/5/Module%20(chicken%20file%20posix) for more details
 
 ;; Open a file to append, open "write only" and create file if it does not exist
 (define outfn (file-open "chicken-hen.txt" (+ open/append open/wronly open/creat)))
@@ -396,14 +394,14 @@ sqr                        ;; => #<procedure (sqr x)>
 
 ;; CHICKEN also supports SRFI (Scheme Requests For Implementation) extensions
 ;; See 'http://srfi.schemers.org/srfi-implementers.html" to see srfi's supported by CHICKEN
-(require-extension srfi-1)         ;; list library
+(import srfi-1)                    ;; list library
 (filter odd? '(1 2 3 4 5 6 7))     ;; => (1 3 5 7)
 (count even? '(1 2 3 4 5))         ;; => 2
 (take '(12 24 36 48 60) 3)         ;; => (12 24 36)
 (drop '(12 24 36 48 60) 2)         ;; => (36 48 60)
 (circular-list 'z 'q)              ;; => z q z q ...
 
-(require-extension srfi-13)        ;; string library
+(import srfi-13)                   ;; string library
 (string-reverse "pan")             ;; => "nap"
 (string-index "Turkey" #\k)        ;; => 3
 (string-every char-upper-case? "CHICKEN") ;; => #t
@@ -448,7 +446,7 @@ sqr                        ;; => #<procedure (sqr x)>
 ; 9. Modules
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Also See http://wiki.call-cc.org/man/4/Modules
+;; Also See http://wiki.call-cc.org/man/5/Modules
 
 ;; The 'test' module exports a value named 'hello' and a macro named 'greet'
 (module test (hello greet)
@@ -509,11 +507,11 @@ sqr                        ;; => #<procedure (sqr x)>
 
 ```
 ## Further Reading
-* [CHICKEN User's Manual](http://wiki.call-cc.org/man/4/The%20User%27s%20Manual).
+* [CHICKEN User's Manual](https://wiki.call-cc.org/manual).
 * [R5RS standards](http://www.schemers.org/Documents/Standards/R5RS)
 
 
 ## Extra Info
 
-* [For programmers of other languages](http://wiki.call-cc.org/chicken-for-programmers-of-other-languages)
+* [For programmers of other languages](https://wiki.call-cc.org/chicken-for-programmers-of-other-languages)
 * [Compare CHICKEN syntax with other languages](http://plr.sourceforge.net/cgi-bin/plr/launch.py)


### PR DESCRIPTION
This change adapt the instructions to CHICKEN 5.  Before it
covered CHICKEN 4, which is an outdated version.

- [ ] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
