### PR TITLE
`[vala/en]`Small correction for vala.html.markdown

### DIFF
--- a/vala.html.markdown
+++ b/vala.html.markdown
@@ -483,7 +483,7 @@ pointer_obj->some_data; // Returns some_data
 delete pointer_obj;
 
 int more = 57;
-int* more_pointer = &i; // & = address-of
+int* more_pointer = &more; // & = address-of
 int indirection_demo = more_pointer*; // indirection
 
 // Profiles: affect which Vala features are avaliable and which libraries the
@@ -494,10 +494,10 @@ int indirection_demo = more_pointer*; // indirection
 // Use "--profile=whatever" when compiling.
 
 ```
-* More Vala documentation can be found [here](https://valadoc.org/).
+* More [Vala documentation](https://valadoc.org/).
 * [Alternate construction syntax](https://wiki.gnome.org/Projects/Vala/Tutorial#GObject-Style_Construction) similar to GObject
-* More on contract programming [here](http://en.wikipedia.org/wiki/Contract_programming)
-* Collections library can be found [here](https://wiki.gnome.org/Projects/Vala/Tutorial#Collections)
+* More on [contract programming](http://en.wikipedia.org/wiki/Contract_programming)
+* [Collections library](https://wiki.gnome.org/Projects/Vala/Tutorial#Collections)
 * [Multithreading](https://wiki.gnome.org/Projects/Vala/Tutorial#Multi-Threading)
-* Read about building GUIs with GTK+ and Vala [here](http://archive.is/7C7bw).
-* D-Bus [integration](https://wiki.gnome.org/Projects/Vala/Tutorial#D-Bus_Integration)
+* Read about [building GUIs with GTK+ and Vala](http://archive.is/7C7bw).
+* [D-Bus integration](https://wiki.gnome.org/Projects/Vala/Tutorial#D-Bus_Integration)


### PR DESCRIPTION
On line 486, replaced &i with &more.
While at it, on lines 497-503 I also transformed all the "here" hyperlinks to their most obvious replacements.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
