### PR TITLE
[toml/en] fix code not rendering

### DIFF
--- a/toml.html.markdown
+++ b/toml.html.markdown
@@ -274,7 +274,8 @@ The equivalent in JSON would be:
 
 The equivalent in JSON would be:
 
-```json
+```
+
 {
   "fruit": [
     {


### PR DESCRIPTION
The json code block renders fine in Github Flavored Markdown on Github, but not on the learnxinyminutes.com/docs/toml page. Because there isn't any syntax highlighting for this section anyway, I switched it to vanilla code block.

- [x ] I solemnly swear that this is all original content of which I am the original author
- [ x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [ x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ na] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [na ] Yes, I have double-checked quotes and field names!
