### PR TITLE
[rust/all] Remove .iter() on array example

### DIFF
--- a/de-de/rust-de.html.markdown
+++ b/de-de/rust-de.html.markdown
@@ -255,7 +255,7 @@ fn main() {
 
     // `for` Schleife/Iterationen
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 

--- a/el-gr/rust-gr.html.markdown
+++ b/el-gr/rust-gr.html.markdown
@@ -242,7 +242,7 @@ fn main() {
 
     // Βρόγχοι `for`
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 

--- a/es-es/rust-es.html.markdown
+++ b/es-es/rust-es.html.markdown
@@ -225,7 +225,7 @@ fn main() {
 
     // bucles `for`
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 

--- a/fr-fr/rust-fr.html.markdown
+++ b/fr-fr/rust-fr.html.markdown
@@ -221,7 +221,7 @@ fn main() {
 
     // `for` boucles / itération
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 

--- a/it-it/rust-it.html.markdown
+++ b/it-it/rust-it.html.markdown
@@ -229,7 +229,7 @@ fn main() {
 
     // Ciclo/iterazione con `for`
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 

--- a/pt-br/rust-pt.html.markdown
+++ b/pt-br/rust-pt.html.markdown
@@ -234,7 +234,7 @@ fn main() {
 
     // `for` laços de repetição/iteração
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 
@@ -329,4 +329,3 @@ mais na página oficial [Rust website](http://rust-lang.org).
 
 No Brasil acompanhe os encontros do [Meetup Rust São Paulo]
 (http://www.meetup.com/pt-BR/Rust-Sao-Paulo-Meetup/).
-

--- a/ru-ru/rust-ru.html.markdown
+++ b/ru-ru/rust-ru.html.markdown
@@ -226,7 +226,7 @@ fn main() {
 
     // `for` loops/iteration
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 

--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -236,7 +236,7 @@ fn main() {
 
     // `for` loops/iteration
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 

--- a/uk-ua/rust-ua.html.markdown
+++ b/uk-ua/rust-ua.html.markdown
@@ -233,7 +233,7 @@ fn main() {
 
     // Цикл `for` 
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 

--- a/zh-cn/rust-cn.html.markdown
+++ b/zh-cn/rust-cn.html.markdown
@@ -211,7 +211,7 @@ fn main() {
 
     // `for` 循环
     let array = [1, 2, 3];
-    for i in array.iter() {
+    for i in array {
         println!("{}", i);
     }
 


### PR DESCRIPTION
As of [Rust 1.53.0](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#intoiterator-for-arrays) arrays implement the IntoIterator trait, so you no longer need to call `.iter()` to iterate over the values of the array.


- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
