### PR TITLE
[qsharp/en] Fix a variable name typo

### DIFF
--- a/qsharp.html.markdown
+++ b/qsharp.html.markdown
@@ -29,10 +29,10 @@ using (qs = Qubit[2]) {
 
     // If you want to change the state of a qubit
     // you have to do this by applying quantum gates to the qubit.
-    H(q[0]);    // This changes the state of the first qubit 
+    H(qs[0]);    // This changes the state of the first qubit 
                 // from |0⟩ (the initial state of allocated qubits) 
                 // to (|0⟩ + |1⟩) / sqrt(2).
-    // q[1] = |1⟩; - this does NOT work, you have to manipulate a qubit by using gates.
+    // qs[1] = |1⟩; - this does NOT work, you have to manipulate a qubit by using gates.
 
     // You can apply multi-qubit gates to several qubits.
     CNOT(qs[0], qs[1]);


### PR DESCRIPTION
`q` is not defined, instead it should be `qs`.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
 - [x] Yes, I have double-checked quotes and field names!
