### PR TITLE
[swift/en] fix typo about break statement in loop

### DIFF
--- a/swift.html.markdown
+++ b/swift.html.markdown
@@ -334,7 +334,7 @@ repeat {
 } while i < 5
 
 // The continue statement continues executing a loop at the next iteration
-// The break statement ends a swift or loop immediately
+// The break statement ends a loop immediately
 
 // MARK: - Functions
 


### PR DESCRIPTION
Just a small fix.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
