### PR TITLE
[lambda-calculus/en] nit: Add caveat to rule 2. `λx.c = Kc`

### DIFF
--- a/lambda-calculus.html.markdown
+++ b/lambda-calculus.html.markdown
@@ -131,7 +131,7 @@ We can convert an expression in the lambda calculus to an expression
 in the SKI combinator calculus:
 
 1. `λx.x = I`
-2. `λx.c = Kc`
+2. `λx.c = Kc` provided that `x` does not occur free in `c`
 3. `λx.(y z) = S (λx.y) (λx.z)`
 
 Take the church number 2 for example:


### PR DESCRIPTION
See this math stackexchange Q/A for the reason why this caveat is important: https://math.stackexchange.com/questions/4304294/rules-for-converting-lambda-calculus-expressions-to-ski-combinator-calculus-expr.

(There may be other clearer ways of wording the caveat. It is also not necessary that the caveat be shown inline with the rules; an alternative is to use a footnote or to make a note below the rules.)

- [x ] I solemnly swear that this is all original content of which I am the original author
- [x ] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [ x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x ] Yes, I have double-checked quotes and field names!
