### PR TITLE
[lua/en] Lua: use of loadstring replaced with load; loadstring is deprecated.

### DIFF
--- a/lua.html.markdown
+++ b/lua.html.markdown
@@ -383,8 +383,9 @@ dofile('mod2.lua')  --> Hi! (runs it again)
 -- loadfile loads a lua file but doesn't run it yet.
 f = loadfile('mod2.lua')  -- Call f() to run it.
 
--- loadstring is loadfile for strings.
-g = loadstring('print(343)')  -- Returns a function.
+-- load is loadfile for strings.
+-- (loadstring is deprecated, use load instead)
+g = load('print(343)')  -- Returns a function.
 g()  -- Prints out 343; nothing printed before now.
 
 --]]


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
