### PR TITLE
[texinfo/en] Fix syntax highlighting

### DIFF
--- a/texinfo.html.markdown
+++ b/texinfo.html.markdown
@@ -16,7 +16,7 @@ what the generator should do.
 
 A simple example of a simple manual:
 
-```texinfo
+```
 \input texinfo
 @setfilename simple-document.info
 @documentencoding UTF-8


### PR DESCRIPTION
Remove syntax highlighting since it's not supported by pygments.

Hopefully, this will allow the page to appear on the website, instead of the current 404.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
