### PR TITLE
[objective-c/en] Add forgotten asterisk in `MyClass` implementation

### DIFF
--- a/objective-c.html.markdown
+++ b/objective-c.html.markdown
@@ -387,7 +387,7 @@ if ([myClass respondsToSelector:selectorVar]) { // Checks if class contains meth
 // Implement the methods in an implementation (MyClass.m) file:
 @implementation MyClass {
     long distance; // Private access instance variable
-    NSNumber height;
+    NSNumber *height;
 }
 
 // To access a public variable from the interface file, use '_' followed by variable name:


### PR DESCRIPTION
Without it, the program doesn't compile:
```
Interface type cannot be statically allocated
```

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
