### PR TITLE
[tools/all] remove language tag from guide for tool/framework

### DIFF
--- a/de-de/qt-de.html.markdown
+++ b/de-de/qt-de.html.markdown
@@ -1,7 +1,6 @@
 ---
 category: tool
 tool: Qt Framework
-language: c++
 filename: learnqt-de.cpp
 contributors:
     - ["Aleksey Kholovchuk", "https://github.com/vortexxx192"]

--- a/id-id/pyqt-id.html.markdown
+++ b/id-id/pyqt-id.html.markdown
@@ -1,7 +1,6 @@
 ---
 category: tool
 tool: PyQt
-language: Python
 filename: learnqt-id.py
 contributors:
     - ["Nathan Hughes", "https://github.com/sirsharpest"]

--- a/it-it/qt-it.html.markdown
+++ b/it-it/qt-it.html.markdown
@@ -1,7 +1,6 @@
 ---
 category: tool
 tool: Qt Framework
-language: c++
 filename: learnqt-it.cpp
 contributors:
     - ["Aleksey Kholovchuk", "https://github.com/vortexxx192"]

--- a/pt-br/qt-pt.html.markdown
+++ b/pt-br/qt-pt.html.markdown
@@ -1,7 +1,6 @@
 ---
 category: tool
 tool: Qt Framework
-language: c++
 filename: learnqt-pt.cpp
 contributors:
     - ["Aleksey Kholovchuk", "https://github.com/vortexxx192"]

--- a/qt.html.markdown
+++ b/qt.html.markdown
@@ -1,7 +1,6 @@
 ---
 category: tool
 tool: Qt Framework
-language: c++
 filename: learnqt.cpp
 contributors:
     - ["Aleksey Kholovchuk", "https://github.com/vortexxx192"]

--- a/ru-ru/qt-ru.html.markdown
+++ b/ru-ru/qt-ru.html.markdown
@@ -1,7 +1,6 @@
 ---
 category: tool
 tool: Qt Framework
-language: c++
 filename: learnqt-ru.cpp
 contributors:
     - ["Aleksey Kholovchuk", "https://github.com/vortexxx192"]

--- a/zh-cn/qt-cn.html.markdown
+++ b/zh-cn/qt-cn.html.markdown
@@ -1,7 +1,6 @@
 ---
 category: tool
 tool: Qt Framework
-language: c++
 filename: learnqt-cn.cpp
 contributors:
     - ["Aleksey Kholovchuk", "https://github.com/vortexxx192"]


### PR DESCRIPTION
- fixes ( #3514 ) ~ish
- remove `language:` tag from all files that have `tool:` tag
  - language overrides tool in generation of page `<title>` and causes
    inconsistencies
- method used:
    ```console
    # used gnu coreutils versions of tools
    grep -R 'tool:' \									# find files with `tool:' tag
    | cut -d: -f1 \										# extract only filenames
    | xargs grep '^language:.*$' \						# find files with `language:' tag
    | cut -d: -f1 \		                     			# extract only filenames
    | xargs -n1 sed -i -e '/^language:.*$/d'` 			# delete line with language tag
    ```

- ~[ ] I solemnly swear that this is all original content of which I am the original author~
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- ~[ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)~
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
