### PR TITLE
[nim and rst/en] Fix typo in comment

### DIFF
--- a/nim.html.markdown
+++ b/nim.html.markdown
@@ -142,7 +142,7 @@ when compileBadCode:
 # Arrays
 
 type
-  RollCounter = array[DieFaces, int]  # Array's are fixed length and
+  RollCounter = array[DieFaces, int]  # Arrays are fixed length and
   DirNames = array[Direction, string] # indexed by any ordinal type.
   Truths = array[42..44, bool]
 var

--- a/rst.html.markdown
+++ b/rst.html.markdown
@@ -33,7 +33,7 @@ $ pip install docutils
 A simple example of the file syntax:
 
 ```
-.. Lines starting with two dots are special commands. But if no command can be found, the line is considered as a comment
+.. Lines starting with two dots are special commands. But if no command can be found, the line is considered as a comment.
 
 =========================================================
 Main titles are written using equals signs over and under
@@ -80,12 +80,12 @@ France      Paris
 Japan       Tokyo
 =========== ========
 
-More complex tables can be done easily (merged columns and/or rows) but I suggest you to read the complete doc for this :)
+More complex tables can be done easily (merged columns and/or rows) but I suggest you to read the complete doc for this. :)
 
 There are multiple ways to make links:
 
 - By adding an underscore after a word : Github_ and by adding the target URL after the text (this way has the advantage of not inserting unnecessary URLs in the visible text).
-- By typing a full comprehensible URL : https://github.com/ (will be automatically converted to a link)
+- By typing a full comprehensible URL : https://github.com/ (will be automatically converted to a link).
 - By making a more Markdown-like link: `Github <https://github.com/>`_ .
 
 .. _Github: https://github.com/


### PR DESCRIPTION
[nim/en] Fixed typo in comment by deleting extra apostrophe

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!