### PR TITLE
[rst/en] Make formatting in comments consistent

### DIFF
--- a/rst.html.markdown
+++ b/rst.html.markdown
@@ -80,12 +80,12 @@ France      Paris
 Japan       Tokyo
 =========== ========
 
-More complex tables can be done easily (merged columns and/or rows) but I suggest you to read the complete doc for this :)
+More complex tables can be done easily (merged columns and/or rows) but I suggest you to read the complete doc for this. :)
 
 There are multiple ways to make links:
 
 - By adding an underscore after a word : Github_ and by adding the target URL after the text (this way has the advantage of not inserting unnecessary URLs in the visible text).
-- By typing a full comprehensible URL : https://github.com/ (will be automatically converted to a link)
+- By typing a full comprehensible URL : https://github.com/ (will be automatically converted to a link).
 - By making a more Markdown-like link: `Github <https://github.com/>`_ .
 
 .. _Github: https://github.com/


### PR DESCRIPTION
Made formatting in RST comments more consistent by adding 2 periods.

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
