### PR TITLE
[fish/en] Fish markdown syntax fixes - spacing, etc

### DIFF
--- a/fish.html.markdown
+++ b/fish.html.markdown
@@ -3,6 +3,7 @@ category: tool
 tool: fish
 contributors:
     - ["MySurmise", "https://github.com/MySurmise"]
+    - ["Geo Maciolek", "https://github.com/GeoffMaciolek"]
 filename: learn.fish
 ---
 
@@ -14,45 +15,64 @@ Examples of these features are autosuggestions, 24-bit colors, Man Page Completi
 
 It was released in February 2005.
 
-[Read more](https://fishshell.com/docs/current/language.html)
+- [Read more](https://fishshell.com/docs/current/language.html)
+- [Installation guide](https://github.com/fish-shell/fish-shell#getting-fish)
 
-[Installation guide](https://github.com/fish-shell/fish-shell#getting-fish)
 
-
-# Guide
+## Guide
 
 Be sure you have the newest fish shell. This was made with version 3.3.0. To test, type:
+
+```
 > fish -v
+```
 
 To start the fish shell, type:
+
+```
 > fish
+```
 
 to exit, type:
+
+```
 > exit
+```
 
 or press <kbd>Ctrl + D</kbd>
 
 Now, right out of the gate, there's one annoying thing in fish. It's the welcome message. Who needs that, right? When your shell is started, just type:
+
+```
 > set -U fish_greeting ""
-
-To set that to the wanted value,  .
-
+```
 
 If you want to execute a single command written in bash, without switching to that shell, you can type:
+
+```
 > bash -c 'echo "fish is better than bash"'
+```
 
 In fish, you can use single or double quotes.
 The escape character is a `\`
 
 You can change your configuration of fish either by editing the config file
+
+```
 > vim ~/.config/fish/config.fish
+```
 
 or by opening the aforementioned web settings:
 
->fish_config
+```
+> fish_config
+```
 
 Adding something to your fish PATH Variable is easy:
+
+```
 > fish_path_add ~/cowsay
+```
 
 Can you do that with bash, huh? No, you always have to look it up... It's just that easy!
 
@@ -60,21 +80,28 @@ But there's more. Most fish-specific commands start, you guessed it, with 'fish'
 Now you can navigate with <kbd>TAB</kbd>, <kbd>Shift + TAB</kbd> and your Arrow-Keys <kbd>←</kbd><kbd>↑</kbd><kbd>→</kbd><kbd>↓</kbd>.
 
 To get help, contact your local psychiatrist or type `man`. That will bring up the manual for that command, for example:
+
+```
 > man set
+```
 
 If you finally tried fish, you can see something other in fish that's really cool. Everything has cool colors, if you type in something wrong, it is red, without even executing, if you put something in quotes, you see where it ends and why that quote doesn't work, because there's another qoutation mark in the quote at position 26. 
 
 fish has even more cool things, like wildcards.
 For example, type
+
+```
 > ls *.fish
+```
 
 That will list all fish files in your current directory.
 
 You can have multiple wildcards per command or even a recursive wildcard, `**`, which basically means it includes files and directories, that fit.
 For example the following command would return (in your case):
-> ls ~/images/**.jpg
 
 ```
+> ls ~/images/**.jpg
+
 ~/images/nudes/pewdiepie.jpg
 ~/images/nudes/peppa.jpg
 ~/images/screenshots/2020-42-69.jpg
@@ -83,72 +110,77 @@ For example the following command would return (in your case):
 
 Of course, you can also pipe the output of a command to another command
 
+```
 >echo sick egg, nadia. no u do really goofy shit.   | grep [udense]
+```
 
 write to a file:
 
+```
 >echo This\ is\ text > file.txt
+```
 
 (noticed the escape character?)
 Add to a file:
 
+```
 >echo This\ is\ a\ line >> file.txt
-
 >echo This\ is\ a\ second\ line >> file.txt
+```
 
 For Autocompletion, just always press <kbd>TAB</kbd>. You will be surprised how many things fish knows.
 
 To use variables, just type `$VAR`, like in bash.
 
+```
 > echo "My home is $HOME"
-
-> My home is /home/myuser
+My home is /home/myuser
+```
 
 Here comes a difference between single and double quotes. If you use a variable in single quotes, it will not substitute it.
 
+```
 > echo 'My home is $HOME'
-
-> My home is $HOME
+My home is $HOME
+```
 
 More on variables later.
 
 To execute two commands, separate them with `;`
+
+```
 > echo Lol; echo this is fun
+```
 
 The status code of the last command is stored in `$status`
 
 You can use && for two commands that depend on each other.
 
+```
 > set var lol && echo $var
+```
 
-You can also use and, 
-which executes if the previous command was successful
-
-or 
-which executes if the previous command was not successful
-
-and not
+You can also use `and`  which executes if the previous command was successful, 
+`or` which executes if the previous command was not successful, and `not`
 which inverts the exit status of a command.
 
 For example:
 
-
-> if not  echo It's very late I should not waste my time with this  
-
->> echo Nobody heard you  
-
->end
+```
+> if not echo It's very late I should not waste my time with this  
+      echo Nobody heard you  
+  end
+```
 
 (You can of course do all of that in the shell)
 
-
 ---
-Now let's start with the scripting part of fish. 
+Now let's start with the scripting part of fish.
 
 As with every shell, you can not only execute commands in the shell, but also as files, saved as a  `.fish` file.
 (You can also execute `.sh` files with fish syntax, but I always use `.fish` for fish-syntax scripts to distinguish them from bash script files)
 
-```bash
+```fish
 # This is a comment in fish.
 # 
 # If you execute a file without specifying an interpreter, 
@@ -165,10 +197,9 @@ As with every shell, you can not only execute commands in the shell, but also as
 # for use inside a program, you can use the syntax
 set name = 'My Variable'
 
-
-# use
+# Use...
 set -x name value
-# to eXport
+# to eXport, or
 set -e name
 # to Erase
 
@@ -188,19 +219,20 @@ count $PATH
 # So $PWD for example is a list of length 1. 
 # To make a list, just give the set command multiple arguments:
 set list entry1 entry2 entry3
+
 # that way you can also append something to an existing variable:
 set PATH $PATH ~/cowsay/
 
 # But, as previously mentioned, we also have a simpler way to do that specifically in fish.
 # As with every Array/List, you can access it with 
 $listvar[2]
+
 # there's also ranges with 
-$listvar[1..5] 
+$listvar[1..5]
+
 # and you can use negative numbers like 
 $listvar[-1]
 # e.g to access the last element.
-
-
 
 # You can also do fancy cartesian products when you combine two list variables:
 set a 1 2 3
@@ -239,7 +271,7 @@ else
     echo Got nothing
 end
 
-# A little weird is that you compare stuff with one = sign , of course because we don't need it to set variables, but still... and the keyword "test":
+# A little weird is that you compare stuff with one = sign, of course because we don't need it to set variables, but still... and the keyword "test":
 if test $var = "test"
     echo yes 
 else 
@@ -304,10 +336,7 @@ end
 # Cool!
 
 # The bashrc equivalent is not fishrc, but the previously mentioned config.fish file in ~/.config/fish/
-
 # To add a function to fish, though, you should create a simple .fish file in that directory. Don't just paste that function in the config.fish. That's ugly. 
-
 # If you have more, just add it, but those are the most important basics.
 
 ```
-


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!

---
(A note for anyone browsing quickly: I'm not the original author of this document; this commit just touches a lot of lines)

I've made some changes to this document to clean up some markdown issues, and to bring it more in-line with existing docs. (The main issue was the use of `>` at the beginning of code lines, leading to [the site](https://learnxinyminutes.com/docs/fish/) rendering "fancy quotes" (`“”` instead of `""`) in chunks of code intended to be copy/pasted, as well as a lack of monospacing etc.

I've elected to use the ` ```fish` header for the large code block, as github's markdown supports this. I've left the other code blocks using bare ` ``` ` marks. (These lines have a have leading `>`, equivalent to `$` in other shells; these would confuse the syntax highlighting.)

There are other changes I'd like to make; those will be for another pull request, I think:
- The generated `learn.fish` isn't what one would expect
- The tone of the article is perhaps more casual than some might prefer
- Some inline code examples could be made somewhat more succinct (with regards to explanation text being split across multiple lines, with the code block between them