### PR TITLE
[powershell/en] Fix and clarify -eq operator on (some) objects

### DIFF
--- a/powershell.html.markdown
+++ b/powershell.html.markdown
@@ -118,14 +118,15 @@ $False - 5   # => -5
 2 -lt 3 -and 3 -lt 2  # => False
 
 # (-is vs. -eq) -is checks if two objects are the same type.
-# -eq checks if the objects have the same values.
+# -eq checks if the objects have the same values, but sometimes doesn't work
+# as expected.
 # Note: we called '[Math]' from .NET previously without the preceeding
 # namespaces. We can do the same with [Collections.ArrayList] if preferred.
 [System.Collections.ArrayList]$a = @()  # Point a at a new list
 $a = (1,2,3,4)
 $b = $a                                 # => Point b at what a is pointing to
 $b -is $a.GetType()                     # => True, a and b equal same type
-$b -eq $a                               # => True, a and b values are equal
+$b -eq $a                               # => None! See below
 [System.Collections.Hashtable]$b = @{}  # => Point a at a new hash table
 $b = @{'one' = 1 
        'two' = 2}
@@ -153,6 +154,13 @@ $age = 22
 # => "Steve said he is 22 years old"
 "$name's name is $($name.Length) characters long." 
 # => "Steve's name is 5 characters long."
+
+# Strings can be compared with -eq, but are case insensitive. We can
+# force with -ceq or -ieq.
+"ab" -eq "ab"  # => True
+"ab" -eq "AB"  # => True!
+"ab" -ceq "AB"  # => False
+"ab" -ieq "AB"  # => True
 
 # Escape Characters in Powershell
 # Many languages use the '\', but Windows uses this character for 
@@ -274,6 +282,10 @@ $array.AddRange($otherArray)  # Now $array is [1, 2, 3, 4, 5, 6]
 # Examine length with "Count" (Note: "Length" on arrayList = each items length)
 $array.Count  # => 6
 
+# -eq doesn't compare array but extract the matching elements
+$array = 1,2,3,1,1
+$array -eq 1          # => 1,1,1
+($array -eq 1).Count  # => 3
 
 # Tuples are like arrays but are immutable.
 # To use Tuples in powershell, you must use the .NET tuple class.


### PR DESCRIPTION
- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)

Hello,

Thanks for this great set of documentation.
Clearly the fastest way for me to acquire rapidly a new language.
There was a small error in powershell regarding -eq operator on array.
I propose a fix in this pull request, and also added some extra tips for strings.

Kind regards,
Xeyownt