### PR TITLE
[swift/ru] s/функционал/функциональность

### DIFF
--- a/ru-ru/swift-ru.html.markdown
+++ b/ru-ru/swift-ru.html.markdown
@@ -622,7 +622,7 @@ class MyShape: Rect {
 // MARK: Прочее
 //
 
-// `extension`s: Добавляет расширенный функционал к существующему типу
+// `extension`s: Добавляет расширенную функциональность к существующему типу
 
 // Класс Square теперь "соответствует" протоколу `CustomStringConvertible`
 extension Square: CustomStringConvertible {


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] Yes, I have double-checked quotes and field names!