### PR TITLE
[r/en] Update content according to R 4.0.0

### DIFF
--- a/r.html.markdown
+++ b/r.html.markdown
@@ -405,7 +405,7 @@ mat
 # [2,]    2    5
 # [3,]    3    6
 # Unlike a vector, the class of a matrix is "matrix", no matter what's in it
-class(mat) # => "matrix"
+class(mat) # => "matrix" "array"
 # Ask for the first row
 mat[1,]	# 1 4
 # Perform operation on the first column

--- a/r.html.markdown
+++ b/r.html.markdown
@@ -4,6 +4,7 @@ contributors:
     - ["e99n09", "http://github.com/e99n09"]
     - ["isomorphismes", "http://twitter.com/isomorphisms"]
     - ["kalinn", "http://github.com/kalinn"]
+    - ["mribeirodantas", "http://github.com/mribeirodantas"]
 filename: learnr.r
 ---
 
@@ -478,9 +479,10 @@ class(students[,3])	# "factor"
 nrow(students)	# 6
 ncol(students)	# 3
 dim(students)	# 6 3
-# The data.frame() function converts character vectors to factor vectors
-# by default; turn this off by setting stringsAsFactors = FALSE when
-# you create the data.frame
+# The data.frame() function used to convert character vectors to factor
+# vectors by default; This has changed in R 4.0.0. If your R version is
+# older, turn this off by setting stringsAsFactors = FALSE when you
+# create the data.frame
 ?data.frame
 
 # There are many twisty ways to subset data frames, all subtly unalike


### PR DESCRIPTION
A matrix is the special case of a two-dimensional ‘array’.  Since R 4.0.0, ‘inherits(m, "array")’ is true for a ‘matrix’ ‘m’, which makes class(mat) return "matrix" "array", not only "matrix" as before. Besides, the default value for stringsAsFactors in the data.frame function has been changed to FALSE since R 4.0.0

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
