### PR TITLE
added some outputs to python3 page

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -622,8 +622,8 @@ def set_global_x(num):
     x = num    # global var x is now set to 6
     print(x)   # => 6
 
-set_x(43)
-set_global_x(6)
+set_x(43)        # => 5
+set_global_x(6)  # => 6
 
 
 # Python has first class functions


### PR DESCRIPTION
set_x(43) and set_global_x(6)  might benefit from having their outputs shown.
currently, it is not clear that set_x only sets x to 43 temporarily

- [ ] I solemnly swear that this is all original content of which I am the original author
- [ ] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [ ] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
