### PR TITLE
[powershell/en] Fix example for hashtable value existence

### DIFF
--- a/powershell.html.markdown
+++ b/powershell.html.markdown
@@ -307,7 +307,7 @@ $filledHash.Values  # => [1, 2, 3]
 
 # Check for existence of keys or values in a hash with "-in"
 "one" -in $filledHash.Keys  # => True
-1 -in $filledHash.Values    # => False
+1 -in $filledHash.Values    # => True
 
 # Looking up a non-existing key returns $null
 $filledHash["four"]  # $null


### PR DESCRIPTION
According to the `$filledHash` definition, 

```powershell
$filledHash = @{"one"= 1 
                "two"= 2 
                "three"= 3}
```

The result of the following command must be `$True` (not `$False`),

```powershell
1 -in $filledHash.Values    # => True
```

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
