### PR TITLE
[awk/en] Update awk.html.markdown

### DIFF
--- a/awk.html.markdown
+++ b/awk.html.markdown
@@ -48,7 +48,7 @@ BEGIN {
     # the preliminary set-up code, before you process any text files. If you
     # have no text files, then think of BEGIN as the main entry point.
 
-    # Variables are global. Just set them or use them, no need to declare..
+    # Variables are global. Just set them or use them, no need to declare.
     count = 0;
 
     # Operators just like in C and friends
@@ -209,7 +209,7 @@ function string_functions(    localvar, arr) {
     # Both return number of matches replaced
     localvar = "fooooobar";
     sub("fo+", "Meet me at the ", localvar); # localvar => "Meet me at the bar"
-    gsub("e+", ".", localvar); # localvar => "m..t m. at th. bar"
+    gsub("e", ".", localvar); # localvar => "m..t m. at th. bar"
 
     # Search for a string that matches a regular expression
     # index() does the same thing, but doesn't allow a regular expression


### PR DESCRIPTION
The `gsub` example is incorrect: with pattern `"e+"`, one gets `"m.t m. at th. bar"`. To get  `"m..t m. at th. bar"` as documented, the pattern is just `"e"`. Otherwise we could keep "e+" but change the result.

Also removed an extra dot at the end of a sentence.

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
