### PR TITLE
correct example of gsub in awk-es

### DIFF
--- a/es-es/awk-es.html.markdown
+++ b/es-es/awk-es.html.markdown
@@ -196,7 +196,7 @@ function string_functions(    localvar, arr) {
     # Ambas regresan el número de matches remplazados.
     localvar = "fooooobar"
     sub("fo+", "Meet me at the ", localvar) # localvar => "Meet me at the bar"
-    gsub("e+", ".", localvar) # localvar => "m..t m. at th. bar"
+    gsub("e", ".", localvar) # localvar => "m..t m. at th. bar"
 
     # Buscar una cadena que haga match con una expresión regular
     # index() hace lo mismo, pero no permite expresiones regulares


### PR DESCRIPTION
Edit is based on the correction in the English edition.[1]

[1] https://github.com/adambard/learnxinyminutes-docs/pull/4437

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
