### PR TITLE
[typescript/en] Update typescript "Further Reading" links

### DIFF
--- a/typescript.html.markdown
+++ b/typescript.html.markdown
@@ -291,7 +291,5 @@ foo.baz = 'hello world'
 
 ## Further Reading
  * [TypeScript Official website] (http://www.typescriptlang.org/)
- * [TypeScript language specifications] (https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md)
- * [Anders Hejlsberg - Introducing TypeScript on Channel 9] (http://channel9.msdn.com/posts/Anders-Hejlsberg-Introducing-TypeScript)
+ * [TypeScript language specifications] (https://github.com/microsoft/TypeScript/blob/main/doc/spec-ARCHIVED.md)
  * [Source Code on GitHub] (https://github.com/Microsoft/TypeScript)
- * [Definitely Typed - repository for type definitions] (http://definitelytyped.org/)


### PR DESCRIPTION
Updated the link to the typescript spec.

Removed dead link to "Anders Hejlsberg - Introducing TypeScript on Channel 9" (I couldn't find a replacement. If there is one, please let me know!)

Finally, "Definitely Typed - repository for type definitions" just points to a dead page.

- [✅] I solemnly swear that this is all original content of which I am the original author
- [✅] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [✅] Pull request touches only one file (or a set of logically related files with similar changes made)
- [✅] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [✅] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [✅] Yes, I have double-checked quotes and field names!
