### PR TITLE
[rdf/en-en] Make color coding generic because too much was red

### DIFF
--- a/rdf.html.markdown
+++ b/rdf.html.markdown
@@ -28,7 +28,7 @@ usually look like URLs but function as identifiers, not locators. The use of
 URIs provides context for resource identifiers to make them unambiguous—for
 example, to tell a book title from a job title.
 
-```turtle
+```
 # The hash symbol is the comment delimiter. 
 
 # Turtle triple statements end with periods like natural language sentences.


### PR DESCRIPTION
The turtle parser that color codes the display didn't understand """ as a closing delimiter, so it turned the second half of the rendered https://learnxinyminutes.com/docs/rdf/ page red. I removed the `turtle` part at the beginning so that it would be a generic code display and not do that.  

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
