### PR TITLE
[racket/en] fix: eq? returns different result in newer version of racket

### DIFF
--- a/racket.html.markdown
+++ b/racket.html.markdown
@@ -348,7 +348,7 @@ m ; => '#hash((b . 2) (a . 1) (c . 3))  <-- no `d'
 (eq? 3 3.0) ; => #f
 
 (eq? (expt 2 100) (expt 2 100))               ; => #f
-(eq? (integer->char 955) (integer->char 955)) ; => #f
+(eq? (integer->char 955) (integer->char 955)) ; => #t
 
 (eq? (string-append "foo" "bar") (string-append "foo" "bar")) ; => #f
 


### PR DESCRIPTION
You can see from https://onecompiler.com/racket/3ymp85q3x that this line returns something different now.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
