### PR TITLE
[javascript/fr-fr] Fix equality comparison example

### DIFF
--- a/fr-fr/javascript-fr.html.markdown
+++ b/fr-fr/javascript-fr.html.markdown
@@ -94,7 +94,7 @@ let banta = "Harry", santa = "Hermione";
 
 // L'égalité est === ou ==
 // === compare la valeur exacte 2 === '2' // = false
-// == convertit la valeur pour comparer 2 === '2' // = true
+// == convertit la valeur pour comparer 2 == '2' // = true
 // En général, il vaut mieux utiliser === pour ne pas faire d'erreur.
 1 === 1; // = true
 2 === 1; // = false


### PR DESCRIPTION
- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)

The French translation added a paragraph to explain the difference between the `==` and `===` operators. However, in this paragraph, `===` was used twice. The example for `==` was using the wrong operator.