### PR TITLE
[vim/de] remove trailing/not needed leading spaces

### DIFF
--- a/de-de/vim-de.html.markdown
+++ b/de-de/vim-de.html.markdown
@@ -12,7 +12,7 @@ filename: LearnVim-de.txt
 
 [Vim](http://www.vim.org)
 (Vi IMproved) ist ein Klon von vi, dem bekannten Editor für Unix. Es ist ein
-Texteditor, welcher mit Fokus auf Geschwindigkeit und Prouktivität entwickelt 
+Texteditor, welcher mit Fokus auf Geschwindigkeit und Prouktivität entwickelt
 wurde.
 Vim hat viele Keybindings für ein schnelles navigieren und schnelles bearbeiten
 einer Datei.
@@ -168,7 +168,7 @@ Einige wichtige Beispiele von 'Verb', 'Modifier' und 'Nouns':
 
     d2w              # lösche zwei Wörter
     cis              # Ändere innerhalb des Satzes.
-    yip              # Kopiere innerhalb des Abschnitts (kopiere den Abschnitt, 
+    yip              # Kopiere innerhalb des Abschnitts (kopiere den Abschnitt,
                      # in welchem du bist)
     ct<              # Ändere bis zur spitzen Klammer
                      # Ändere den Text von deiner aktuellen Cursorposition bis
@@ -181,7 +181,7 @@ Einige wichtige Beispiele von 'Verb', 'Modifier' und 'Nouns':
 ```
     >                # Rücke die Auswahl um einen Block ein
     <                # Lösche eine Einrückung der Auswahl
-    :earlier 15m     # Stellt das Dokument so wieder her, wie es vor 15 
+    :earlier 15m     # Stellt das Dokument so wieder her, wie es vor 15
                      # Minuten war
     :later 15m       # den oberen Befehl rückgängig machen
     ddp              # Vertauschen zweier aufeinanderfolgenden Zeilen
@@ -195,7 +195,7 @@ Einige wichtige Beispiele von 'Verb', 'Modifier' und 'Nouns':
     ~                # Umschalten der Groß-/Kleinschreibung des ausgewählten Textes
     u                # Ausgewählten Text zu Kleinschreibung ändern
     U                # Ausgewählten Text zu Großschreibung ändern
-    
+
     # Text-Folding (Textfaltung)
     zf               # Erstelle eine Faltung des ausgewählten Textes
     zo               # Öffne die aktuelle Faltung

--- a/de-de/vim-de.html.markdown
+++ b/de-de/vim-de.html.markdown
@@ -3,9 +3,9 @@ category: tool
 tool: vim
 lang: de-de
 contributors:
-    - ["RadhikaG", "https://github.com/RadhikaG"]
+- ["RadhikaG", "https://github.com/RadhikaG"]
 translators:
-    - ["caminsha", "https://github.com/caminsha"]
+- ["caminsha", "https://github.com/caminsha"]
 filename: LearnVim-de.txt
 ---
 
@@ -20,74 +20,74 @@ einer Datei.
 ## Grundlagen, um in Vim zu navigieren
 
 ```
-    vim <filename>   # Öffne <filename> in Vim
-    :help <topic>    # Öffne die eingebaute Hilfe zum Thema  <topic>, wenn
-                     # es existiert
-    :q               # Schließe vim
-    :w               # Speichere diese Datei
-    :wq              # Speichere diese Datei und schließe vim
-    ZZ               # Speichere diese Datei und schließe vim
-    :q!              # Schließe vim ohne die Datei zu speichern
-                     # ! *zwingt* die Ausführung von :q,
-                     # daher wird die Datei nicht gespeichert.
-    ZQ               # Beende vim ohne die Datei zu speichern
-    :x               # Speichere die Datei und beende vim
-                     # Dies ist eine kürzere Version von :wq
+vim <filename>   # Öffne <filename> in Vim
+:help <topic>    # Öffne die eingebaute Hilfe zum Thema  <topic>, wenn
+# es existiert
+:q               # Schließe vim
+:w               # Speichere diese Datei
+:wq              # Speichere diese Datei und schließe vim
+ZZ               # Speichere diese Datei und schließe vim
+:q!              # Schließe vim ohne die Datei zu speichern
+# ! *zwingt* die Ausführung von :q,
+# daher wird die Datei nicht gespeichert.
+ZQ               # Beende vim ohne die Datei zu speichern
+:x               # Speichere die Datei und beende vim
+# Dies ist eine kürzere Version von :wq
 
-    u                # Änderung rückgängig machen
-    CTRL+R           # Änderung wiederherstellen
+u                # Änderung rückgängig machen
+CTRL+R           # Änderung wiederherstellen
 
-    h                # Den Cursor um ein Zeichen nach links bewegen
-    j                # Den Cursor eine Zeile nach unten bewegen
-    k                # Den Cursor eine Zeile nach oben bewegen
-    l                # Den Cursor um ein Zeichen nach rechts bewegen
+h                # Den Cursor um ein Zeichen nach links bewegen
+j                # Den Cursor eine Zeile nach unten bewegen
+k                # Den Cursor eine Zeile nach oben bewegen
+l                # Den Cursor um ein Zeichen nach rechts bewegen
 
-    Ctrl+B 	         # Gehe eine Bildschirmanzeige zurück
-    Ctrl+F 	         # Gehe eine Bildschirmanzeige vorwärts
-    Ctrl+D 	         # Gehe eine halbe Bildschirmanzeige vorwärts
-    Ctrl+U           # Gehe eine halbe Bildschirmanzeige zurück
+Ctrl+B 	         # Gehe eine Bildschirmanzeige zurück
+Ctrl+F 	         # Gehe eine Bildschirmanzeige vorwärts
+Ctrl+D 	         # Gehe eine halbe Bildschirmanzeige vorwärts
+Ctrl+U           # Gehe eine halbe Bildschirmanzeige zurück
 
-    # Navigieren innerhalb einer Zeile
+# Navigieren innerhalb einer Zeile
 
-    0                # Navigiere zum Anfang der Zeile
-    $                # Navigiere zum Ende der Zeile
-    ^                # Navigiere zum ersten Zeichen, welches kein Leerzeichen ist
+0                # Navigiere zum Anfang der Zeile
+$                # Navigiere zum Ende der Zeile
+^                # Navigiere zum ersten Zeichen, welches kein Leerzeichen ist
 
-    # Im Text suchen
+# Im Text suchen
 
-    /word            # Hebt alle Ergebnisse nach dem Cursor hervor
-    ?word            # Hebt alle Ergebnisse vor dem Cursor hervor
-    n                # Bewegt den Cursor zum nächsten Ergebnis nach der Suche
-    N                # Bewegt den Cursor zum vorherigen Ergebnis der Suche
+/word            # Hebt alle Ergebnisse nach dem Cursor hervor
+?word            # Hebt alle Ergebnisse vor dem Cursor hervor
+n                # Bewegt den Cursor zum nächsten Ergebnis nach der Suche
+N                # Bewegt den Cursor zum vorherigen Ergebnis der Suche
 
-    :%s/foo/bar/g    # Ersetze "foo" durch "bar" in allen Zeilen
-    :s/foo/bar/g     # Ersetze "foo" durch "bar" in der aktuellen Zeile
-    :%s/\n/\r/g      # Ersetze das newline-Zeichen bei allen Zeilen durch
-                     # ein carriage return
+:%s/foo/bar/g    # Ersetze "foo" durch "bar" in allen Zeilen
+:s/foo/bar/g     # Ersetze "foo" durch "bar" in der aktuellen Zeile
+:%s/\n/\r/g      # Ersetze das newline-Zeichen bei allen Zeilen durch
+# ein carriage return
 
-    # Zu einzelnen Zeichen springen
+# Zu einzelnen Zeichen springen
 
-    f<character>     # Springe vorwärts und auf dem Zeichen  <character>
-    t<character>     # Springe vorwärts und lande vor dem Zeichen <character>
+f<character>     # Springe vorwärts und auf dem Zeichen  <character>
+t<character>     # Springe vorwärts und lande vor dem Zeichen <character>
 
-    # Zum Beispiel,
-    f<               # Springe vorwärts und lande auf <
-    t<               # Springe vorwärts und lande vor <
+# Zum Beispiel,
+f<               # Springe vorwärts und lande auf <
+t<               # Springe vorwärts und lande vor <
 
-    # Wortweise navigieren
+# Wortweise navigieren
 
-    w                # Springe um ein Wort vorwärts
-    b                # Gehe ein Wort zurück
-    e                # Springe zum Ende des aktuellen Wortes
+w                # Springe um ein Wort vorwärts
+b                # Gehe ein Wort zurück
+e                # Springe zum Ende des aktuellen Wortes
 
-    # Weitere Befehle, um zu navigieren
+# Weitere Befehle, um zu navigieren
 
-    gg               # Gehe an den Start der Datei
-    G                # Gehe an das Ende der Datei
-    :NUM             # Springe zur Zeile NUM (NUM kann eine beliebige Zahl sein)
-    H                # Navigiere zum Start der aktuellen Bildschirmanzeige
-    M                # Navigiere in die Mitte der aktuellen Bildschirmanzeige
-    L                # Navigiere an das Ende der aktuellen Bildschirmanzeige
+gg               # Gehe an den Start der Datei
+G                # Gehe an das Ende der Datei
+:NUM             # Springe zur Zeile NUM (NUM kann eine beliebige Zahl sein)
+H                # Navigiere zum Start der aktuellen Bildschirmanzeige
+M                # Navigiere in die Mitte der aktuellen Bildschirmanzeige
+L                # Navigiere an das Ende der aktuellen Bildschirmanzeige
 ```
 
 ## Hilfsdokumente:
@@ -110,22 +110,22 @@ Vim basiert auf dem Konzept von **modes**.
 - Ex Mode      - Wird verwendet, um im ':'-Prompt Befehle einzugeben
 
 ```
-    i                # Führt vim in den Insert Mode, vor der Cursorposition
-    a                # Führt vim in den Insert Mode, nach der Cursorposition
-    v                # Führt vim in den Visual Mode
-    :                # Führt vim in den Ex Mode
-    <esc>            # Führt zurück in den Command Mode, egal in welchem Mode
-                     # man sich gerade befindet.
+i                # Führt vim in den Insert Mode, vor der Cursorposition
+a                # Führt vim in den Insert Mode, nach der Cursorposition
+v                # Führt vim in den Visual Mode
+:                # Führt vim in den Ex Mode
+<esc>            # Führt zurück in den Command Mode, egal in welchem Mode
+# man sich gerade befindet.
 
-    # Kopieren und einfügen von Text
+# Kopieren und einfügen von Text
 
-    y                # Kopiere alles, was im Moment ausgewählt ist
-    yy               # Kopiert die aktuelle Zeile
-    d                # Löscht alles, was im Moment ausgewählt ist
-    dd               # Löscht die aktuelle Zeile
-    p                # Fügt den kopierten Text nach dem Cursor ein
-    P                # Fügt den kopierten Text vor dem Cursor ein
-    x                # Löscht das Zeichen unter dem Cursor
+y                # Kopiere alles, was im Moment ausgewählt ist
+yy               # Kopiert die aktuelle Zeile
+d                # Löscht alles, was im Moment ausgewählt ist
+dd               # Löscht die aktuelle Zeile
+p                # Fügt den kopierten Text nach dem Cursor ein
+P                # Fügt den kopierten Text vor dem Cursor ein
+x                # Löscht das Zeichen unter dem Cursor
 ```
 
 ## Die 'Grammatik' von Vim
@@ -140,68 +140,68 @@ Vim kann als Satz von Kommandos angesehen werden, welche im Format
 Einige wichtige Beispiele von 'Verb', 'Modifier' und 'Nouns':
 
 ```
-    # 'Verb'
+# 'Verb'
 
-    d                # löschen
-    c                # ändern
-    y                # kopieren
-    v                # visuelles auswählen
+d                # löschen
+c                # ändern
+y                # kopieren
+v                # visuelles auswählen
 
-    # 'Modifiers'
+# 'Modifiers'
 
-    i                # innerhalb
-    a                # außerhalb
-    NUM              # Nummer (NUM kann irgendeine Zahl sein)
-    f                # Sucht nach etwas und landet darauf
-    t                # Sucht nach etwas und stoppt davor
-    /                # Suche eine Zeichenfolge ab dem Cursor
-    ?                # Suche eine Zeichenfolge vor dem Cursor
+i                # innerhalb
+a                # außerhalb
+NUM              # Nummer (NUM kann irgendeine Zahl sein)
+f                # Sucht nach etwas und landet darauf
+t                # Sucht nach etwas und stoppt davor
+/                # Suche eine Zeichenfolge ab dem Cursor
+?                # Suche eine Zeichenfolge vor dem Cursor
 
-    # 'Nouns'
+# 'Nouns'
 
-    w                # Wort
-    s                # Satz
-    p                # Abschnitt
-    b                # Block
+w                # Wort
+s                # Satz
+p                # Abschnitt
+b                # Block
 
-    # Beispielsätze resp. Kommandos
+# Beispielsätze resp. Kommandos
 
-    d2w              # lösche zwei Wörter
-    cis              # Ändere innerhalb des Satzes.
-    yip              # Kopiere innerhalb des Abschnitts (kopiere den Abschnitt,
-                     # in welchem du bist)
-    ct<              # Ändere bis zur spitzen Klammer
-                     # Ändere den Text von deiner aktuellen Cursorposition bis
-                     # zur nächsten spitzen Klammer
-    d$               # Lösche bis zum Ende der Zeile
+d2w              # lösche zwei Wörter
+cis              # Ändere innerhalb des Satzes.
+yip              # Kopiere innerhalb des Abschnitts (kopiere den Abschnitt,
+# in welchem du bist)
+ct<              # Ändere bis zur spitzen Klammer
+# Ändere den Text von deiner aktuellen Cursorposition bis
+# zur nächsten spitzen Klammer
+d$               # Lösche bis zum Ende der Zeile
 ```
 
 ## Einige Shortcuts und Tricks
 
 ```
-    >                # Rücke die Auswahl um einen Block ein
-    <                # Lösche eine Einrückung der Auswahl
-    :earlier 15m     # Stellt das Dokument so wieder her, wie es vor 15
-                     # Minuten war
-    :later 15m       # den oberen Befehl rückgängig machen
-    ddp              # Vertauschen zweier aufeinanderfolgenden Zeilen
-                     # Zuerst dd, dann p
-    .                # Wiederhole die vorherige Aktion
-    :w !sudo tee %   # Speichere die Datei als Root
-    :set syntax=c    # Stelle das Syntax-Highlighting für 'C' ein
-    :sort            # Alle Zeilen sortieren
-    :sort!           # Alle Zeilen rückwärts sortieren
-    :sort u          # Alle Zeilen sortieren und Duplikate entfernen
-    ~                # Umschalten der Groß-/Kleinschreibung des ausgewählten Textes
-    u                # Ausgewählten Text zu Kleinschreibung ändern
-    U                # Ausgewählten Text zu Großschreibung ändern
+>                # Rücke die Auswahl um einen Block ein
+<                # Lösche eine Einrückung der Auswahl
+:earlier 15m     # Stellt das Dokument so wieder her, wie es vor 15
+# Minuten war
+:later 15m       # den oberen Befehl rückgängig machen
+ddp              # Vertauschen zweier aufeinanderfolgenden Zeilen
+# Zuerst dd, dann p
+.                # Wiederhole die vorherige Aktion
+:w !sudo tee %   # Speichere die Datei als Root
+:set syntax=c    # Stelle das Syntax-Highlighting für 'C' ein
+:sort            # Alle Zeilen sortieren
+:sort!           # Alle Zeilen rückwärts sortieren
+:sort u          # Alle Zeilen sortieren und Duplikate entfernen
+~                # Umschalten der Groß-/Kleinschreibung des ausgewählten Textes
+u                # Ausgewählten Text zu Kleinschreibung ändern
+U                # Ausgewählten Text zu Großschreibung ändern
 
-    # Text-Folding (Textfaltung)
-    zf               # Erstelle eine Faltung des ausgewählten Textes
-    zo               # Öffne die aktuelle Faltung
-    zc               # Schließe die aktuelle Faltung
-    zR               # Öffne alle Faltungen
-    zM               # Schließe alle Faltungen
+# Text-Folding (Textfaltung)
+zf               # Erstelle eine Faltung des ausgewählten Textes
+zo               # Öffne die aktuelle Faltung
+zc               # Schließe die aktuelle Faltung
+zR               # Öffne alle Faltungen
+zM               # Schließe alle Faltungen
 ```
 
 ## Makros
@@ -212,9 +212,9 @@ Kommandos, welche du braucht, aufgenommen bis die Aufnahme gestoppt wird.
 Wenn du ein Makro ausführst, werden exakt die gleichen Schritte gemacht.
 
 ```
-    qa               # Starte das Aufnehmen des Makros 'a'
-    q                # Beende das Aufnehmen
-    @a               # Führe das Makro 'a' aus
+qa               # Starte das Aufnehmen des Makros 'a'
+q                # Beende das Aufnehmen
+@a               # Führe das Makro 'a' aus
 ```
 
 ### Konfigurieren mit ~/.vimrc

--- a/de-de/vim-de.html.markdown
+++ b/de-de/vim-de.html.markdown
@@ -101,7 +101,7 @@ Hilfsdialog an, welcher den Start mit vim einfacher macht.
 
 Vim basiert auf dem Konzept von **modes**.
 
-- Command Mode - Vim erster Modus, hier kann man navigieren und Befehle eingeben
+- Command Mode - Vims erster Modus, hier kann man navigieren und Befehle eingeben
 - Insert Mode  - Wird verwendet, um Änderungen in der Datei zu machen.
 - Visual Mode  - Wird verwendet, um Text zu markieren und diesen zu verändern
 - Ex Mode      - Wird verwendet, um im ':'-Prompt Befehle einzugeben

--- a/de-de/vim-de.html.markdown
+++ b/de-de/vim-de.html.markdown
@@ -13,26 +13,25 @@ filename: LearnVim-de.txt
 [Vim](http://www.vim.org)
 (Vi IMproved) ist ein Klon von vi, dem bekannten Editor für Unix. Es ist ein
 Texteditor, welcher mit Fokus auf Geschwindigkeit und Prouktivität entwickelt
-wurde.
-Vim hat viele Keybindings für ein schnelles navigieren und schnelles bearbeiten
-einer Datei.
+wurde. Vim hat viele Keybindings für ein schnelles navigieren und schnelles
+bearbeiten einer Datei.
 
 ## Grundlagen, um in Vim zu navigieren
 
 ```
 vim <filename>   # Öffne <filename> in Vim
 :help <topic>    # Öffne die eingebaute Hilfe zum Thema  <topic>, wenn
-# es existiert
+                 # es existiert
 :q               # Schließe vim
 :w               # Speichere diese Datei
 :wq              # Speichere diese Datei und schließe vim
 ZZ               # Speichere diese Datei und schließe vim
 :q!              # Schließe vim ohne die Datei zu speichern
-# ! *zwingt* die Ausführung von :q,
-# daher wird die Datei nicht gespeichert.
+                 # ! *zwingt* die Ausführung von :q,
+                 # daher wird die Datei nicht gespeichert.
 ZQ               # Beende vim ohne die Datei zu speichern
 :x               # Speichere die Datei und beende vim
-# Dies ist eine kürzere Version von :wq
+                 # Dies ist eine kürzere Version von :wq
 
 u                # Änderung rückgängig machen
 CTRL+R           # Änderung wiederherstellen
@@ -63,7 +62,7 @@ N                # Bewegt den Cursor zum vorherigen Ergebnis der Suche
 :%s/foo/bar/g    # Ersetze "foo" durch "bar" in allen Zeilen
 :s/foo/bar/g     # Ersetze "foo" durch "bar" in der aktuellen Zeile
 :%s/\n/\r/g      # Ersetze das newline-Zeichen bei allen Zeilen durch
-# ein carriage return
+                 # ein carriage return
 
 # Zu einzelnen Zeichen springen
 
@@ -115,7 +114,7 @@ a                # Führt vim in den Insert Mode, nach der Cursorposition
 v                # Führt vim in den Visual Mode
 :                # Führt vim in den Ex Mode
 <esc>            # Führt zurück in den Command Mode, egal in welchem Mode
-# man sich gerade befindet.
+                 # man sich gerade befindet.
 
 # Kopieren und einfügen von Text
 
@@ -169,10 +168,10 @@ b                # Block
 d2w              # lösche zwei Wörter
 cis              # Ändere innerhalb des Satzes.
 yip              # Kopiere innerhalb des Abschnitts (kopiere den Abschnitt,
-# in welchem du bist)
+                 # in welchem du bist)
 ct<              # Ändere bis zur spitzen Klammer
-# Ändere den Text von deiner aktuellen Cursorposition bis
-# zur nächsten spitzen Klammer
+                 # Ändere den Text von deiner aktuellen Cursorposition bis
+                 # zur nächsten spitzen Klammer
 d$               # Lösche bis zum Ende der Zeile
 ```
 
@@ -181,11 +180,10 @@ d$               # Lösche bis zum Ende der Zeile
 ```
 >                # Rücke die Auswahl um einen Block ein
 <                # Lösche eine Einrückung der Auswahl
-:earlier 15m     # Stellt das Dokument so wieder her, wie es vor 15
-# Minuten war
+:earlier 15m     # Stellt das Dokument so wieder her, wie es vor 15 Minuten war
 :later 15m       # den oberen Befehl rückgängig machen
 ddp              # Vertauschen zweier aufeinanderfolgenden Zeilen
-# Zuerst dd, dann p
+                 # Zuerst dd, dann p
 .                # Wiederhole die vorherige Aktion
 :w !sudo tee %   # Speichere die Datei als Root
 :set syntax=c    # Stelle das Syntax-Highlighting für 'C' ein

--- a/de-de/vim-de.html.markdown
+++ b/de-de/vim-de.html.markdown
@@ -12,7 +12,7 @@ filename: LearnVim-de.txt
 
 [Vim](http://www.vim.org)
 (Vi IMproved) ist ein Klon von vi, dem bekannten Editor für Unix. Es ist ein
-Texteditor, welcher mit Fokus auf Geschwindigkeit und Prouktivität entwickelt
+Texteditor, welcher mit Fokus auf Geschwindigkeit und Produktivität entwickelt
 wurde. Vim hat viele Keybindings für ein schnelles navigieren und schnelles
 bearbeiten einer Datei.
 
@@ -97,7 +97,6 @@ Zum Beispiel öffnet `:help navigation` die Dokumentation über das Navigieren
 
 `:help` kann auch ohne ein Argument verwendet werden. Dies zeigt den Standard-
 Hilfsdialog an, welcher den Start mit vim einfacher macht.
-that aims to make getting started with vim more approachable!
 
 ## Modi:
 

--- a/de-de/vim-de.html.markdown
+++ b/de-de/vim-de.html.markdown
@@ -9,7 +9,6 @@ translators:
 filename: LearnVim-de.txt
 ---
 
-
 [Vim](http://www.vim.org)
 (Vi IMproved) ist ein Klon von vi, dem bekannten Editor für Unix. Es ist ein
 Texteditor, welcher mit Fokus auf Geschwindigkeit und Produktivität entwickelt
@@ -41,9 +40,9 @@ j                # Den Cursor eine Zeile nach unten bewegen
 k                # Den Cursor eine Zeile nach oben bewegen
 l                # Den Cursor um ein Zeichen nach rechts bewegen
 
-Ctrl+B 	         # Gehe eine Bildschirmanzeige zurück
-Ctrl+F 	         # Gehe eine Bildschirmanzeige vorwärts
-Ctrl+D 	         # Gehe eine halbe Bildschirmanzeige vorwärts
+Ctrl+B           # Gehe eine Bildschirmanzeige zurück
+Ctrl+F           # Gehe eine Bildschirmanzeige vorwärts
+Ctrl+D           # Gehe eine halbe Bildschirmanzeige vorwärts
 Ctrl+U           # Gehe eine halbe Bildschirmanzeige zurück
 
 # Navigieren innerhalb einer Zeile
@@ -89,7 +88,7 @@ M                # Navigiere in die Mitte der aktuellen Bildschirmanzeige
 L                # Navigiere an das Ende der aktuellen Bildschirmanzeige
 ```
 
-## Hilfsdokumente:
+## Hilfsdokumente
 
 Vim hat eine eingebaute Dokumentation, welche mit `:help <topic>` aufgerufen
 werden kann.
@@ -98,13 +97,13 @@ Zum Beispiel öffnet `:help navigation` die Dokumentation über das Navigieren
 `:help` kann auch ohne ein Argument verwendet werden. Dies zeigt den Standard-
 Hilfsdialog an, welcher den Start mit vim einfacher macht.
 
-## Modi:
+## Modi
 
 Vim basiert auf dem Konzept von **modes**.
 
-- Command Mode - Vim startet in diesem Modus, hier kann man navigieren und Befehle eingeben
+- Command Mode - Vim erster Modus, hier kann man navigieren und Befehle eingeben
 - Insert Mode  - Wird verwendet, um Änderungen in der Datei zu machen.
-- Visual Mode  - Wird verwendet, um Text zu markieren und Operationen durchzuführen
+- Visual Mode  - Wird verwendet, um Text zu markieren und diesen zu verändern
 - Ex Mode      - Wird verwendet, um im ':'-Prompt Befehle einzugeben
 
 ```


### PR DESCRIPTION
Many lines in the code blocks included leading spaces not needed, these and
trailing spaces were removed.  An additional light edit (no remove/add of
features presented) to stay within the limit of 80 characters/line.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)

