### PR TITLE
[bash/en]correct function return description

### DIFF
--- a/bash.html.markdown
+++ b/bash.html.markdown
@@ -419,8 +419,8 @@ function foo ()
     echo "Arguments work just like script arguments: $@"
     echo "And: $1 $2..."
     echo "This is a function"
-    returnValue=0    # Variable values can be returned
-    return $returnValue
+    returnValue=0    # Functions in Bash only return status codes(integers of range 0-255)
+    return $returnValue # Using the return command is optional
 }
 # Call the function `foo` with two arguments, arg1 and arg2:
 foo arg1 arg2
@@ -439,6 +439,10 @@ bar ()
 }
 # Call the function `bar` with no arguments:
 bar # => Another way to declare functions!
+
+# Capture function stdout outputs using command substitution
+barResult=$(bar)
+echo barResult # => Another way to declare functions!
 
 # Calling your function
 foo "My name is" $Name


### PR DESCRIPTION
Functions can't return any type other than an integer within the range 0-255. This represents the exit status code of the function. In order to actually capture function output, we need to either use global variables or stdout.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
