### PR TITLE
[markdown/cs-cz] Remove frontmatter duplicated `cs-cz` lang entry

### DIFF
--- a/cs-cz/markdown.html.markdown
+++ b/cs-cz/markdown.html.markdown
@@ -1,6 +1,5 @@
 ---
 language: markdown
-lang: cs-cz
 contributors:
     - ["Dan Turkel", "http://danturkel.com/"]
 translators:

--- a/de-de/processing-de.html.markdown
+++ b/de-de/processing-de.html.markdown
@@ -1,6 +1,5 @@
 ---
 language: processing
-filename: learnprocessing.pde
 contributors:
     - ["Phone Thant Ko", "http://github.com/phonethantko"]
     - ["Divay Prakash", "https://github.com/divayprakash"]

--- a/groovy.html.markdown
+++ b/groovy.html.markdown
@@ -1,9 +1,8 @@
 ---
 language: Groovy
-filename: learngroovy.groovy
 contributors:
     - ["Roberto Pérez Alcolea", "http://github.com/rpalcolea"]
-filename: learngroovy.groovy
+filename: groovy.html.markdown
 ---
 
 Groovy - A dynamic language for the Java platform [Read more here.](http://www.groovy-lang.org/)

--- a/pl-pl/java-pl.html.markdown
+++ b/pl-pl/java-pl.html.markdown
@@ -1,6 +1,5 @@
 ---
 language: java
-filename: LearnJavaPl.java
 contributors:
     - ["Jake Prather", "https://github.com/JakeHP"]
     - ["Jakukyo Friel", "https://weakish.github.io"]


### PR DESCRIPTION
at cs-cz/markdown.html.markdown

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
