### PR TITLE
[set-theory/en] Add the vertical bar qualifier explanation

### DIFF
--- a/set-theory.html.markdown
+++ b/set-theory.html.markdown
@@ -17,7 +17,7 @@ Set theory is a branch of mathematics that studies sets, their operations, and t
 * the cross operator, `×`, means "the Cartesian product of".
 
 ### Qualifiers 
-* the colon qualifier, `:`, means "such that";
+* the colon, `:`, or the vertical bar `|` qualifiers are interchangeable and mean "such that";
 * the membership qualifier, `∈`, means "belongs to";
 * the subset qualifier, `⊆`, means "is a subset of";
 * the proper subset qualifier, `⊂`, means "is a subset of but is not equal to".


### PR DESCRIPTION
The vertical bar qualifier explanation is missing, but it's widely used interchangeably with the colon qualifier. Even it the text you use "|" so it should be explained as well.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
