### PR TITLE
[rust/en] Add fibonacci example output comment

### DIFF
--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -223,7 +223,7 @@ fn main() {
     type FunctionPointer = fn(u32) -> u32;
 
     let fib : FunctionPointer = fibonacci;
-    println!("Fib: {}", fib(4));
+    println!("Fib: {}", fib(4)); // 5
 
     /////////////////////////
     // 3. Pattern matching //


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!

This just adds a comment showing what the output would be for one of the examples.

Most of the `println` examples on this page use this style of comment, but this example was missing one.
