### PR TITLE
[ruby/en] Fix code typo in ruby.html.markdown

### DIFF
--- a/ruby.html.markdown
+++ b/ruby.html.markdown
@@ -170,7 +170,7 @@ status == 'pending' #=> false
 status == :approved #=> false
 
 # Strings can be converted into symbols and vice versa.
-status.to_s #=> "pending"
+:status.to_s #=> "pending"
 "argon".to_sym #=> :argon
 
 # Arrays


### PR DESCRIPTION
Adds a missing colon before the `status` symbol in ruby.html.markdown.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
 - [x] Yes, I have double-checked quotes and field names!
