### PR TITLE
'[git]' fix typo in blame section so code block can appear properly

### DIFF
--- a/git.html.markdown
+++ b/git.html.markdown
@@ -583,7 +583,8 @@ $ git rm /pather/to/the/file/HelloWorld.c
 ```
 
 ### blame
-Examine specific parts of the code's history and find out who was the last author to modify that line
+Examine specific parts of the code's history and find out who was the last author to modify that line.
+
 ```bash
 # find the authors on the latest modified lines
 $ git blame google_python_style.vim


### PR DESCRIPTION
Code block wasn't rendering properly because there wasn't a line break before it.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
