### PR TITLE
[go/en] - Fix go math library alias

### DIFF
--- a/go.html.markdown
+++ b/go.html.markdown
@@ -46,7 +46,7 @@ package main
 import (
 	"fmt"       // A package in the Go standard library.
 	"io/ioutil" // Implements some I/O utility functions.
-	"math"    // Math library with local alias m.
+	m "math"    // Math library with local alias m.
 	"net/http"  // Yes, a web server!
 	"os"        // OS functions like working with the file system
 	"strconv"   // String conversions.


### PR DESCRIPTION
Fix go math library alias

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
- [x] Yes, I have double-checked quotes and field names!
