### PR TITLE
[kotlin/en] Parentheses can be omitted for single lambda args

### DIFF
--- a/kotlin.html.markdown
+++ b/kotlin.html.markdown
@@ -127,7 +127,10 @@ fun helloWorld(val name : String) {
     // Named functions can be specified as arguments using the :: operator.
     val notOdd = not(::odd)
     val notEven = not(::even)
-    // Lambda expressions can be specified as arguments.
+    /*
+    Lambda expressions can be specified as arguments.
+    If it's the only argument parentheses can be omitted.
+    */
     val notZero = not {n -> n == 0}
     /*
     If a lambda has only one parameter


### PR DESCRIPTION
This was introduced without explanation IMO.

Had to look it up here:
https://kotlinlang.org/docs/lambdas.html#passing-trailing-lambdas

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
