### PR TITLE
[rst/en] use 'markup' instead of 'markdown'

### DIFF
--- a/rst.html.markdown
+++ b/rst.html.markdown
@@ -8,7 +8,7 @@ filename: restructuredtext.rst
 
 RST, Restructured Text, is a file format created by the Python community to write documentation. It is part of [Docutils](https://docutils.sourceforge.io/rst.html).
 
-RST is a markdown language like HTML but is much more lightweight and easier to read.
+RST is a markup language like HTML but is much more lightweight and easier to read.
 
 
 ## Installation


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!

Since _'markdown'_ is actually one kind of [_'markup languages'_](https://en.wikipedia.org/wiki/Markup_language), it seems better to use _'markup'_ here.