### PR TITLE
[dart/en] Fixed typo

### DIFF
--- a/dart.html.markdown
+++ b/dart.html.markdown
@@ -45,7 +45,7 @@ const CONSTANT_VALUE = "I CANNOT CHANGE";
 CONSTANT_VALUE = "DID I?"; //Error
 /// Final is another variable declaration that cannot be change once it has been instantiated. Commonly used in classes and functions
 /// `final` can be declared in pascalCase.
-final finalValue = "value cannot be change once instantiated";
+final finalValue = "value cannot be changed once instantiated";
 finalValue = "Seems not"; //Error
 
 /// `var` is another variable declaration that is mutable and can change its value. Dart will infer types and will not change its data type


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
