### PR TITLE
[python/en] add hint about leading underscore indicating internal use

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -733,7 +733,9 @@ class Human:
         self.name = name
 
         # Initialize property
-        self._age = 0
+        self._age = 0   # the leading underscore indicates the "age" property is 
+                        # intended to be used internally
+                        # do not rely on this to be enforced: it's a hint to other devs
 
     # An instance method. All methods take "self" as the first argument
     def say(self, msg):


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
