### PR TITLE
[python/en] Fix incorrect expression description

### DIFF
--- a/python.html.markdown
+++ b/python.html.markdown
@@ -226,7 +226,7 @@ li[4]  # Raises an IndexError
 li[1:3]   # Return list from index 1 to 3 => [2, 4]
 li[2:]    # Return list starting from index 2 => [4, 3]
 li[:3]    # Return list from beginning until index 3  => [1, 2, 4]
-li[::2]   # Return list selecting every second entry => [1, 4]
+li[::2]   # Return list selecting elements with a step size of 2 => [1, 4]
 li[::-1]  # Return list in reverse order => [3, 4, 2, 1]
 # Use any combination of these to make advanced slices
 # li[start:end:step]


### PR DESCRIPTION
The description of expression `li[::2]` as "selecting every second entry" is incorrect (and misleading) as it is, in fact, selecting every second entry starting from and including the 1st entry. The correct expression for "selecting every second entry" would be `li[1::2]`.

```
li = [1, 2, 3, 4, 5, 6]
li[::2] # => [1, 3, 5]
li[1::2] # => [2, 4, 6]
```

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
