### PR TITLE
[rust/en] Include resource for advanced Rust projects

### DIFF
--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -353,3 +353,7 @@ irc.mozilla.org are also always keen to help newcomers.
 You can also try out features of Rust with an online compiler at the official
 [Rust playpen](http://play.rust-lang.org) or on the main
 [Rust website](http://rust-lang.org).
+
+If you're looking for Rust projects to build, CodeCrafters has a 
+[Rust track](https://app.codecrafters.io/tracks/rust) where you can recreate
+popular developer tools from scratch in Rust (e.g Build your own BitTorrent).


### PR DESCRIPTION
Adding CodeCrafters, which is commonly recommended as the appropriate resource for intermediate to advanced-level practice projects. Here's a [Jon Gjengset stream](https://www.youtube.com/watch?v=jf_ddGnum_4&t=200s&ab_channel=JonGjengset) doing Build your own BitTorrent.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
