### PR TITLE
[elixir/en] Give more context around Elixir comparison operators

### DIFF
--- a/elixir.html.markdown
+++ b/elixir.html.markdown
@@ -147,13 +147,15 @@ nil && 20  #=> nil
 1 == 1.0  #=> true
 1 === 1.0 #=> false
 
-# We can also compare two different data types:
+# Elixir operators are strict in theiar arguments, with the exception
+# of comparison operators that work across different data types:
 1 < :hello #=> true
 
-# The overall sorting order is defined below:
-# number < atom < reference < functions < port < pid < tuple < list < bit string
+# This enables building collections of mixed types:
+["string", 123, :atom]
 
-# To quote Joe Armstrong on this: "The actual order is not important,
+# While there is an overall order of all data types,
+# to quote Joe Armstrong on this: "The actual order is not important,
 # but that a total ordering is well defined is important."
 
 ## ---------------------------


### PR DESCRIPTION
The overall order confuses people but it is not important.
We also add some background on why it matters.

This is based on feedback from maintaining Elixir and its official docs. :)

Thank you!

---

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
