### PR TITLE
[mongodb/en] correct operator order

### DIFF
--- a/mongodb.html.markdown
+++ b/mongodb.html.markdown
@@ -252,17 +252,17 @@ db.engineers.deleteMany({ gender: 'Male' })
 //////////////// Comparison Operators ///////////////////
 
 // Find all greater than or greater than equal to some condition
-db.engineers.find({ $gt: { age: 25 }})
-db.engineers.find({ $gte: { age: 25 }})
+db.engineers.find({ age: { $gt: 25 }})
+db.engineers.find({ age: { $gte: 25 }})
 
 // Find all less than or less than equal to some condition
-db.engineers.find({ $lt: { age: 25 }})
-db.engineers.find({ $lte: { age: 25 }})
+db.engineers.find({ age: { $lt: 25 }})
+db.engineers.find({ age: { $lte: 25 }})
 
 // Find all equal or not equal to
 // Note: the $eq operator is added implicitly in most queries
-db.engineers.find({ $eq: { age: 25 }})
-db.engineers.find({ $ne: { age: 25 }})
+db.engineers.find({ age: { $eq: 25 }})
+db.engineers.find({ age: { $ne: 25 }})
 
 // Find all that match any element in the array, or not in the array
 db.engineers.find({ age: { $in: [ 20, 23, 24, 25 ]}})


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
- [x] Yes, I have double-checked quotes and field names!
