### PR TITLE
[zfs/en-en] Reconcile ZFS pool names for all examples and remove some garbage

### DIFF
--- a/zfs.html.markdown
+++ b/zfs.html.markdown
@@ -3,6 +3,7 @@ category: tool
 tool: zfs
 contributors:
     - ["sarlalian", "http://github.com/sarlalian"]
+    - ["A1EF", "https://github.com/A1EF"]
 filename: LearnZfs.txt
 ---
 
@@ -25,7 +26,6 @@ RAID setup with ZFS, as ZFS expects to directly manage the underlying disks.
 
 Types of VDEV's
 
-* stripe (a single disk, no redundancy)
 * mirror (n-way mirrors supported)
 * raidz
 	* raidz1 (1-disk parity, similar to RAID 5)
@@ -71,7 +71,7 @@ List zpools
 
 ```bash
 # Create a raidz zpool
-$ zpool create bucket raidz1 gpt/zfs0 gpt/zfs1 gpt/zfs2
+$ zpool create zroot raidz1 gpt/zfs0 gpt/zfs1 gpt/zfs2
 
 # List ZPools
 $ zpool list
@@ -160,22 +160,22 @@ Create datasets
 
 ```bash
 # Create dataset
-$ zfs create tank/root/data
+$ zfs create zroot/root/data
 $ mount | grep data
-tank/root/data on /data (zfs, local, nfsv4acls)
+zroot/root/data on /data (zfs, local, nfsv4acls)
 
 # Create child dataset
-$ zfs create tank/root/data/stuff
+$ zfs create zroot/root/data/stuff
 $ mount | grep data
-tank/root/data on /data (zfs, local, nfsv4acls)
-tank/root/data/stuff on /data/stuff (zfs, local, nfsv4acls)
+zroot/root/data on /data (zfs, local, nfsv4acls)
+zroot/root/data/stuff on /data/stuff (zfs, local, nfsv4acls)
 
 
 # Create Volume
 $ zfs create -V zroot/win_vm
 $ zfs list zroot/win_vm
 NAME                 USED  AVAIL  REFER  MOUNTPOINT
-tank/win_vm         4.13G  17.9G    64K  -
+zroot/win_vm         4.13G  17.9G    64K  -
 ```
 
 List datasets
@@ -213,28 +213,28 @@ zroot/var/tmp@daily-2015-10-15                                                  
 Rename datasets
 
 ```bash
-$ zfs rename tank/root/home tank/root/old_home
-$ zfs rename tank/root/new_home tank/root/home
+$ zfs rename zroot/root/home zroot/root/old_home
+$ zfs rename zroot/root/new_home zroot/root/home
 ```
 
 Delete dataset
 
 ```bash
 # Datasets cannot be deleted if they have any snapshots
-$ zfs destroy tank/root/home
+$ zfs destroy zroot/root/home
 ```
 
 Get / set properties of a dataset
 
 ```bash
 # Get all properties
-$ zfs get all  zroot/usr/home                                                                                              │157 # Create Volume
-NAME            PROPERTY              VALUE                  SOURCE                                                                          │158 $ zfs create -V zroot/win_vm
-zroot/home      type                  filesystem             -                                                                               │159 $ zfs list zroot/win_vm
-zroot/home      creation              Mon Oct 20 14:44 2014  -                                                                               │160 NAME                 USED  AVAIL  REFER  MOUNTPOINT
-zroot/home      used                  11.9G                  -                                                                               │161 tank/win_vm         4.13G  17.9G    64K  -
-zroot/home      available             94.1G                  -                                                                               │162 ```
-zroot/home      referenced            11.9G                  -                                                                               │163
+$ zfs get all zroot/usr/home
+NAME            PROPERTY              VALUE                  SOURCE
+zroot/home      type                  filesystem             -
+zroot/home      creation              Mon Oct 20 14:44 2014  -
+zroot/home      used                  11.9G                  -
+zroot/home      available             94.1G                  -
+zroot/home      referenced            11.9G                  -
 zroot/home      mounted               yes                    -
 ...
 
@@ -244,7 +244,7 @@ NAME            PROPERTY     VALUE     SOURCE
 zroot/home      compression  off       default
 
 # Set property on dataset
-$ zfs set compression=gzip-9 mypool/lamb
+$ zfs set compression=lz4 zroot/lamb
 
 # Get a set of properties from all datasets
 $ zfs list -o name,quota,reservation
@@ -283,16 +283,16 @@ Create snapshots
 
 ```bash
 # Create a snapshot of a single dataset
-zfs snapshot tank/home/sarlalian@now
+zfs snapshot zroot/home/sarlalian@now
 
 # Create a snapshot of a dataset and its children
-$ zfs snapshot -r tank/home@now
+$ zfs snapshot -r zroot/home@now
 $ zfs list -t snapshot
 NAME                       USED  AVAIL  REFER  MOUNTPOINT
-tank/home@now                 0      -    26K  -
-tank/home/sarlalian@now       0      -   259M  -
-tank/home/alice@now           0      -   156M  -
-tank/home/bob@now             0      -   156M  -
+zroot/home@now                 0      -    26K  -
+zroot/home/sarlalian@now       0      -   259M  -
+zroot/home/alice@now           0      -   156M  -
+zroot/home/bob@now             0      -   156M  -
 ...
 ```
 
@@ -300,10 +300,10 @@ Destroy snapshots
 
 ```bash
 # How to destroy a snapshot
-$ zfs destroy tank/home/sarlalian@now
+$ zfs destroy zroot/home/sarlalian@now
 
 # Delete a snapshot on a parent dataset and its children
-$ zfs destroy -r tank/home/sarlalian@now
+$ zfs destroy -r zroot/home/sarlalian@now
 
 ```
 
@@ -311,10 +311,10 @@ Renaming Snapshots
 
 ```bash
 # Rename a snapshot
-$ zfs rename tank/home/sarlalian@now tank/home/sarlalian@today
-$ zfs rename tank/home/sarlalian@now today
+$ zfs rename zroot/home/sarlalian@now zroot/home/sarlalian@today
+$ zfs rename zroot/home/sarlalian@now today
 
-$ zfs rename -r tank/home@now @yesterday
+$ zfs rename -r zroot/home@now @yesterday
 ```
 
 Accessing snapshots
@@ -328,26 +328,26 @@ Sending and Receiving
 
 ```bash
 # Backup a snapshot to a file
-$ zfs send tank/home/sarlalian@now | gzip > backup_file.gz
+$ zfs send zroot/home/sarlalian@now | gzip > backup_file.gz
 
 # Send a snapshot to another dataset
-$ zfs send tank/home/sarlalian@now | zfs recv backups/home/sarlalian
+$ zfs send zroot/home/sarlalian@now | zfs recv backups/home/sarlalian
 
 # Send a snapshot to a remote host
-$ zfs send tank/home/sarlalian@now | ssh root@backup_server 'zfs recv tank/home/sarlalian'
+$ zfs send zroot/home/sarlalian@now | ssh root@backup_server 'zfs recv zroot/home/sarlalian'
 
 # Send full dataset with snapshots to new host
-$ zfs send -v -R tank/home@now | ssh root@backup_server 'zfs recv tank/home'
+$ zfs send -v -R zroot/home@now | ssh root@backup_server 'zfs recv zroot/home'
 ```
 
 Cloning Snapshots
 
 ```bash
 # Clone a snapshot
-$ zfs clone tank/home/sarlalian@now tank/home/sarlalian_new
+$ zfs clone zroot/home/sarlalian@now zroot/home/sarlalian_new
 
 # Promoting the clone so it is no longer dependent on the snapshot
-$ zfs promote tank/home/sarlalian_new
+$ zfs promote zroot/home/sarlalian_new
 ```
 
 ### Putting it all together


### PR DESCRIPTION
- Consolidate ZFS pool names in examples
- Remove `stripe` VDEV type
- Change example with compression
- Remove garbage in examples

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
