### PR TITLE
[fortran/en] account for non-functional typo

### DIFF
--- a/fortran90.html.markdown
+++ b/fortran90.html.markdown
@@ -438,7 +438,7 @@ end module fruity
 
 
 ! ISO Standard Fortran 2008 introduced the DO CONCURRENT construct to allow you
-! to express loop-level parallelis
+! to express loop-level parallelism
 
 integer :: i
 real :: array(100)

--- a/fortran90.html.markdown
+++ b/fortran90.html.markdown
@@ -437,7 +437,8 @@ contains
 end module fruity
 
 
-! ISO Standard Fortran 2008 introduced the DO CONCURRENT construct to allow you to express loop-level parallelism
+! ISO Standard Fortran 2008 introduced the DO CONCURRENT construct to allow you
+! to express loop-level parallelis
 
 integer :: i
 real :: array(100)
@@ -447,7 +448,8 @@ DO CONCURRENT (i = 1:size(array))
 END DO
 
 
-! Only calls to pure functions are allowed inside the loop and we can declare multiple indices:
+! Only calls to pure functions are allowed inside the loop and we can declare
+! multiple indices:
 
 integer :: x, y
 real :: array(8, 16)

--- a/fortran90.html.markdown
+++ b/fortran90.html.markdown
@@ -436,6 +436,34 @@ contains
 
 end module fruity
 
+
+! ISO Standard Fortran 2008 introduced the DO CONCURRENT construct to allow you to express loop-level parallelism
+
+integer :: i
+real :: array(100)
+
+DO CONCURRENT (i = 1:size(array))
+    array(i) = sqrt(i**i)
+END DO
+
+
+! Only calls to pure functions are allowed inside the loop and we can declare multiple indices:
+
+integer :: x, y
+real :: array(8, 16)
+
+do concurrent (x = 1:size(array, 1), y = 1:size(array, 2))
+    array(x, y) = real(x)
+end do
+
+! loop indices can also declared inside the contruct:
+
+real :: array(8, 16)
+
+do concurrent (integer :: x = 1:size(array, 1), y = 1:size(array, 2))
+    array(x, y) = real(x)
+end do
+
 ```
 
 ### More Resources


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
