### PR TITLE
[CPP/en] Added content for string length

### DIFF
--- a/c++.html.markdown
+++ b/c++.html.markdown
@@ -236,6 +236,12 @@ cout << myString.length() + myOtherString.size();
 myString.append(" Dog");
 cout << myString; // "Hello Dog"
 
+// C++ can handle C-style strings with related functions using cstrings
+#include <cstring>
+
+char myOldString[20] = "Hello CPP";
+cout << myOldString;
+cout << "Length = " << strlen(myOldString); // Length = 9
 
 /////////////
 // References

--- a/c++.html.markdown
+++ b/c++.html.markdown
@@ -228,6 +228,10 @@ cout << myString + myOtherString; // "Hello World"
 
 cout << myString + " You"; // "Hello You"
 
+// Outputs 11 (= 5 + 6).
+// C++ string length can be found from either string::length() or string::size()
+cout << myString.length() + myOtherString.size();
+
 // C++ strings are mutable.
 myString.append(" Dog");
 cout << myString; // "Hello Dog"


### PR DESCRIPTION
Updated string length support from C++ using `string::length()` and `string::size()` from the included <strings> header file and additionally including <cstrings> header to show finding length for C-compliant char* pointer or char[] array type strings with `strlen()`.

# Checklist
- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
