### PR TITLE
[gdscript/*] update NodePath literal syntax

### DIFF
--- a/gdscript.html.markdown
+++ b/gdscript.html.markdown
@@ -220,19 +220,19 @@ func _ready() -> void:
   # Create NodePath by passing String to its constructor:
   var path1 = NodePath("path/to/something")
   # Or by using NodePath literal:
-  var path2 = @"path/to/something"
+  var path2 = ^"path/to/something"
   # NodePath examples:
-  var path3 = @"Sprite" # relative path, immediate child of the current node
-  var path4 = @"Timers/Firerate" # relative path, child of the child
-  var path5 = @".." # current node's parent
-  var path6 = @"../Enemy" # current node's sibling
-  var path7 = @"/root" # absolute path, equivalent to get_tree().get_root()
-  var path8 = @"/root/Main/Player/Sprite" # absolute path to Player's Sprite
-  var path9 = @"Timers/Firerate:wait_time" # accessing properties
-  var path10 = @"Player:position:x" # accessing subproperties
+  var path3 = ^"Sprite" # relative path, immediate child of the current node
+  var path4 = ^"Timers/Firerate" # relative path, child of the child
+  var path5 = ^".." # current node's parent
+  var path6 = ^"../Enemy" # current node's sibling
+  var path7 = ^"/root" # absolute path, equivalent to get_tree().get_root()
+  var path8 = ^"/root/Main/Player/Sprite" # absolute path to Player's Sprite
+  var path9 = ^"Timers/Firerate:wait_time" # accessing properties
+  var path10 = ^"Player:position:x" # accessing subproperties
 
   # Finally, to get a reference use one of these:
-  sprite = get_node(@"Sprite") as Sprite # always cast to the type you expect
+  sprite = get_node(^"Sprite") as Sprite # always cast to the type you expect
   sprite = get_node("Sprite") as Sprite # here String gets
                                         # implicitly casted to NodePath
   sprite = get_node(path3) as Sprite
@@ -249,7 +249,7 @@ func _process(delta):
 onready var tween = $Tween as Tween
 
 # You can export NodePath, so you can assign it within the inspector.
-export var nodepath = @""
+export var nodepath = ^""
 onready var reference = get_node(nodepath) as Node
 ```
 

--- a/zh-cn/gdscript-cn.html.markdown
+++ b/zh-cn/gdscript-cn.html.markdown
@@ -215,19 +215,19 @@ func _ready() -> void:
   # 将 String 传递给其构造函数来创建 NodePath：
   var path1 = NodePath("path/to/something")
   # 或者使用 NodePath 字面量:
-  var path2 = @"path/to/something"
+  var path2 = ^"path/to/something"
   # NodePath 示例:
-  var path3 = @"Sprite" # 相对路径，当前节点的直接子节点
-  var path4 = @"Timers/Firerate" # 相对路径，子节点的子节点
-  var path5 = @".." # 当前节点的父节点
-  var path6 = @"../Enemy" # 当前节点的兄弟节点
-  var path7 = @"/root" # 绝对路径，等价于 get_tree().get_root()
-  var path8 = @"/root/Main/Player/Sprite" # Player 的 Sprite 的绝对路径
-  var path9 = @"Timers/Firerate:wait_time" # 访问属性
-  var path10 = @"Player:position:x" # 访问子属性
+  var path3 = ^"Sprite" # 相对路径，当前节点的直接子节点
+  var path4 = ^"Timers/Firerate" # 相对路径，子节点的子节点
+  var path5 = ^".." # 当前节点的父节点
+  var path6 = ^"../Enemy" # 当前节点的兄弟节点
+  var path7 = ^"/root" # 绝对路径，等价于 get_tree().get_root()
+  var path8 = ^"/root/Main/Player/Sprite" # Player 的 Sprite 的绝对路径
+  var path9 = ^"Timers/Firerate:wait_time" # 访问属性
+  var path10 = ^"Player:position:x" # 访问子属性
 
   # 最后，获取节点引用可以使用以下方法:
-  sprite = get_node(@"Sprite") as Sprite # 始终转换为您期望的类型
+  sprite = get_node(^"Sprite") as Sprite # 始终转换为您期望的类型
   sprite = get_node("Sprite") as Sprite # 这里 String 被隐式转换为 NodePath
   sprite = get_node(path3) as Sprite
   sprite = get_node_or_null("Sprite") as Sprite
@@ -242,7 +242,7 @@ func _process(delta):
 onready var tween = $Tween as Tween
 
 # 您可以导出这个 NodePath，以便在检查器中给它赋值。
-export var nodepath = @""
+export var nodepath = ^""
 onready var reference = get_node(nodepath) as Node
 ```
 


### PR DESCRIPTION
@Wichamir it seems like this was changed in GDScript 4

https://docs.godotengine.org/en/3.0/classes/class_nodepath.html#description

https://docs.godotengine.org/en/4.0/classes/class_nodepath.html#description

Could you read over your page again, maybe there are other things that need updating?