### PR TITLE
[hy/en]  drop square brackets for conditionals

### DIFF
--- a/hy.html.markdown
+++ b/hy.html.markdown
@@ -159,12 +159,9 @@ True ; => True
 
 ; nest multiple if else if clauses with cond
 (cond
- [(= someval 42)
-  (print "Life, universe and everything else!")]
- [(> someval 42)
-  (print "val too large")]
- [(< someval 42)
-  (print "val too small")])
+  (= someval 42) (print "Life, universe and everything else!")
+  (> someval 42) (print "val too large")
+  (< someval 42) (print "val too small"))
 
 ; group statements with do, these are executed sequentially
 ; forms like defn have an implicit do


### PR DESCRIPTION
In my testing it looks like hy dropped square brackets for conditionals.

- [ x] I solemnly swear that this is all original content of which I am the original author
- [x ] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
