### PR TITLE
rust/es-es

### DIFF
--- a/es-es/rust-es.html.markdown
+++ b/es-es/rust-es.html.markdown
@@ -85,7 +85,7 @@ fn main() {
     // Un `String` – una cadena en memoria dinámica (heap)
     let s: String = "hola mundo".to_string();
 
-    // Una porión de cadena (slice) – una vista inmutable a otra cadena
+    // Una porción de cadena (slice) – una vista inmutable a otra cadena
     // Esto es básicamente un puntero inmutable a un string string – en realidad
     // no contiene los caracteres de la cadena, solo un puntero a algo que los
     // tiene (en este caso, `s`)


### PR DESCRIPTION
Le faltaba la 'c' a la palabra porción, decía porión. Línea 88

- [ ] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
