### PR TITLE
[rust/es-es] fix variable name

### DIFF
--- a/es-es/rust-es.html.markdown
+++ b/es-es/rust-es.html.markdown
@@ -275,7 +275,7 @@ fn main() {
     *ahora_es_mio += 2;
 
     println!("{}", ahora_es_mio); // 7
-    // println!("{}", mio); // esto no compilaría, porque `now_its_mine` es el
+    // println!("{}", mio); // esto no compilaría, porque `ahora_es_mio` es el
     // que posee el puntero
 
     // Referencia – un puntero inmutable que referencia a otro dato


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
