### PR TITLE
[elixir/en] Typo Fix

### DIFF
--- a/elixir.html.markdown
+++ b/elixir.html.markdown
@@ -146,7 +146,7 @@ nil && 20  #=> nil
 1 == 1.0  #=> true
 1 === 1.0 #=> false
 
-# Elixir operators are strict in theiar arguments, with the exception
+# Elixir operators are strict in their arguments, with the exception
 # of comparison operators that work across different data types:
 1 < :hello #=> true
 


### PR DESCRIPTION
This PR fixes a small typo in the `Elixir` docs, where `theiar` should be `their`.



- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
