### PR TITLE
[go/fr-fr] chore: update Go Mobile link to go.dev

### DIFF
--- a/fi-fi/go-fi.html.markdown
+++ b/fi-fi/go-fi.html.markdown
@@ -438,4 +438,4 @@ lähdekoodi tulee esille!
 Toinen loistava paikka oppia on [Go by example](https://gobyexample.com/).
 
 Go Mobile lisää tuen mobiilialustoille (Android ja iOS). Voit kirjoittaa pelkällä Go:lla natiiveja applikaatioita tai tehdä kirjaston joka sisältää sidoksia
-Go-paketista, jotka puolestaan voidaan kutsua Javasta (Android) ja Objective-C:stä (iOS). Katso [lisätietoja](https://github.com/golang/go/wiki/Mobile).
+Go-paketista, jotka puolestaan voidaan kutsua Javasta (Android) ja Objective-C:stä (iOS). Katso [lisätietoja](https://go.dev/wiki/Mobile).


### PR DESCRIPTION
The Go wiki on GitHub has moved to go.dev 
The old link was broken, Updating the link ensures doc remains accurate and helpful.

- [x] I solemnly swear that this is all original content of which I am the original author
- [ ] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
