### PR TITLE
[rust/en] Fix typo/grammatical error in Rust section

### DIFF
--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -99,7 +99,7 @@ fn main() {
     // A string slice – an immutable view into another string
     // This is basically an immutable pair of pointers to a string – it doesn’t
     // actually contain the contents of a string, just a pointer to
-    // the begin and a pointer to the end of a string buffer,
+    // the beginning and a pointer to the end of a string buffer,
     // statically allocated or contained in another object (in this case, `s`).
     // The string slice is like a view `&[u8]` into `Vec<T>`.
     let s_slice: &str = &s;


### PR DESCRIPTION
Fix typo/grammatical error in Rust section. Changed "begin" -> "beginning" on string slice section for clarity. Fix typo/grammatical error in Rust section

- [x] I solemnly swear that this is all original content of which I am the original author

- [x] Pull request title is prepended with [language/lang-code] (example [python/fr-fr] or [java/en])

- [x] Pull request touches only one file (or a set of logically related files with similar changes made)

- [x] Content changes are aimed at intermediate to experienced programmers (this is a poor format for explaining fundamental programming concepts)

- [x] The YAML Frontmatter was not changed.