### PR TITLE
[python/es] remove unnecessary parentheses

### DIFF
--- a/es-es/python-es.html.markdown
+++ b/es-es/python-es.html.markdown
@@ -551,7 +551,7 @@ def decir(decir_por_favor=False):
 
 
 print(decir())  # ¿Puedes comprarme una cerveza?
-print(decir(decir_por_favor=True))  # ¿Puedes comprarme una cerveza? ¡Por favor! Soy pobre :()
+print(decir(decir_por_favor=True))  # ¿Puedes comprarme una cerveza? ¡Por favor! Soy pobre :(
 ```
 
 ## ¿Listo para más?


### PR DESCRIPTION
This PR merely serves to:

- Remove an unnecessary closing parenthesis in one of the comments showing the result, as it would not be the result shown in the comment.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
