### PR TITLE
[rust/en] fix a typo and make some explanations clearer

### DIFF
--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -92,14 +92,14 @@ fn main() {
     println!("{} {}", f, x); // 1.3 hello world
 
     // A `String` – a heap-allocated string
-    // Stored as a `Vec<u8>` and always hold a valid UTF-8 sequence, 
+    // It is stored as a `Vec<u8>` and always holds a valid UTF-8 sequence, 
     // which is not null terminated.
     let s: String = "hello world".to_string();
 
     // A string slice – an immutable view into another string
-    // This is basically an immutable pair of pointers to a string – it doesn’t
-    // actually contain the contents of a string, just a pointer to
-    // the beginning and a pointer to the end of a string buffer,
+    // This is basically just an immutable pointer and length of a string – it
+    // doesn’t actually contain the contents of a string, just a pointer to
+    // the beginning and a length of a string buffer,
     // statically allocated or contained in another object (in this case, `s`).
     // The string slice is like a view `&[u8]` into `Vec<T>`.
     let s_slice: &str = &s;
@@ -162,6 +162,8 @@ fn main() {
     let up = Direction::Up;
 
     // Enum with fields
+    // If you want to make something optional, the standard
+    // library has `Option`
     enum OptionalI32 {
         AnI32(i32),
         Nothing,
@@ -175,6 +177,8 @@ fn main() {
     struct Foo<T> { bar: T }
 
     // This is defined in the standard library as `Option`
+    // `Option` is used in place of where a null pointer
+    // would normally be used.
     enum Optional<T> {
         SomeVal(T),
         NoVal,
@@ -304,7 +308,7 @@ fn main() {
     /////////////////////////////////
 
     // Owned pointer – only one thing can ‘own’ this pointer at a time
-    // This means that when the `Box` leaves its scope, it can be automatically deallocated safely.
+    // This means that when the `Box` leaves its scope, it will be automatically deallocated safely.
     let mut mine: Box<i32> = Box::new(3);
     *mine = 5; // dereference
     // Here, `now_its_mine` takes ownership of `mine`. In other words, `mine` is moved.

--- a/rust.html.markdown
+++ b/rust.html.markdown
@@ -92,12 +92,12 @@ fn main() {
     println!("{} {}", f, x); // 1.3 hello world
 
     // A `String` – a heap-allocated string
-    // It is stored as a `Vec<u8>` and always holds a valid UTF-8 sequence, 
+    // Stored as a `Vec<u8>` and always holds a valid UTF-8 sequence, 
     // which is not null terminated.
     let s: String = "hello world".to_string();
 
     // A string slice – an immutable view into another string
-    // This is basically just an immutable pointer and length of a string – it
+    // This is basically an immutable pointer and length of a string – it
     // doesn’t actually contain the contents of a string, just a pointer to
     // the beginning and a length of a string buffer,
     // statically allocated or contained in another object (in this case, `s`).


### PR DESCRIPTION
There was a small typo in one of the comments. Additionally, `&str` is internally a `&[u8]` which stores its state as a pointer and length, not two pointers.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
