### PR TITLE
[yaml/en] Fix key names in yaml.html.markdown

### DIFF
--- a/yaml.html.markdown
+++ b/yaml.html.markdown
@@ -84,20 +84,20 @@ folded_style: >
 
 # |- and >- removes the trailing blank lines (also called literal/block "strip")
 literal_strip: |-
-  This entire block of text will be the value of the 'literal_block' key,
+  This entire block of text will be the value of the 'literal_strip' key,
   with trailing blank line being stripped.
 block_strip: >-
-  This entire block of text will be the value of 'folded_style', but this
+  This entire block of text will be the value of 'block_strip', but this
   time, all newlines will be replaced with a single space and 
   trailing blank line being stripped.
 
 # |+ and >+ keeps trailing blank lines (also called literal/block "keep")
 literal_keep: |+
-  This entire block of text will be the value of the 'literal_block' key,
+  This entire block of text will be the value of the 'literal_keep' key,
   with trailing blank line being kept.
 
 block_keep: >+
-  This entire block of text will be the value of 'folded_style', but this
+  This entire block of text will be the value of 'block_keep', but this
   time, all newlines will be replaced with a single space and 
   trailing blank line being kept.
 


### PR DESCRIPTION
Two value description texts contain the wrong key name. This commit corrects both key names in the description texts.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
