### PR TITLE
[java/pl-pl] Remove duplicate `filename` header field

### DIFF
--- a/pl-pl/java-pl.html.markdown
+++ b/pl-pl/java-pl.html.markdown
@@ -13,7 +13,6 @@ contributors:
     - ["Rob Rose", "https://github.com/RobRoseKnows"]
     - ["Sean Nam", "https://github.com/seannam"]
     - ["Shawn M. Hanes", "https://github.com/smhanes15"]
-filename: LearnJava.java
 translators:
     - ["Jacek Wachowiak", "https://github.com/jacekwachowiak"]
 lang: pl-pl


### PR DESCRIPTION
The duplicate `filename` field clashes with the English version

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
