### PR TITLE
[go/en] minor wording: disambiguate "close" in learnDefer()

### DIFF
--- a/go.html.markdown
+++ b/go.html.markdown
@@ -323,7 +323,7 @@ func learnDefer() (ok bool) {
 	defer fmt.Println("deferred statements execute in reverse (LIFO) order.")
 	defer fmt.Println("\nThis line is being printed first because")
 	// Defer is commonly used to close a file, so the function closing the
-	// file stays close to the function opening the file.
+	// file stays near the function opening the file.
 	return true
 }
 


### PR DESCRIPTION
In the same sentence, the word "close" was used to refer to "to close the file" and "is close to another line of code".

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
 - [x] Yes, I have double-checked quotes and field names!
