### PR TITLE
[zig/en] Remove incorrect comment in enum section

### DIFF
--- a/zig.html.markdown
+++ b/zig.html.markdown
@@ -588,9 +588,6 @@ const x = switch (direction) {
     .South => true,
 };
 
-
-// Switch statements need exhaustiveness.
-// Won't compile: East and West are missing.
 const x = switch (direction) {
     .North => true,
     .South => true,

--- a/zig.html.markdown
+++ b/zig.html.markdown
@@ -588,6 +588,7 @@ const x = switch (direction) {
     .South => true,
 };
 
+// This compiles without errors, since it exhaustively lists all possible values
 const x = switch (direction) {
     .North => true,
     .South => true,


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
