### PR TITLE
[lua/*] Update links to Lua Short Reference

### DIFF
--- a/es-es/lua.html.markdown
+++ b/es-es/lua.html.markdown
@@ -426,7 +426,7 @@ Luego, leí el libro oficial de [Programación en Lua](http://www.lua.org/pil/co
 Ese es el cómo.
 
 Podría serle útil darle un vistazo a
-[Lua Short Reference](http://lua-users.org/wiki/LuaShortReference) en lua-users.org.
+[Lua Short Reference](http://lua-users.org/files/wiki_insecure/users/thomasl/luarefv51.pdf) en lua-users.org.
 
 Los principales temas no cubiertos son las librerías estándar:
 

--- a/fr-fr/lua-fr.html.markdown
+++ b/fr-fr/lua-fr.html.markdown
@@ -435,7 +435,7 @@ les librairies standard:
 Autres références complémentaires:
 
 * [Lua pour programmeurs](http://nova-fusion.com/2012/08/27/lua-for-programmers-part-1/)
-* [Référence condensée de Lua](lua-users.org/files/wiki_insecure/users/thomasl/luarefv51.pdf)
+* [Référence condensée de Lua](http://lua-users.org/files/wiki_insecure/users/thomasl/luarefv51.pdf)
 * [Programmer en Lua](http://www.lua.org/pil/contents.html)
 * [Les manuels de référence Lua](http://www.lua.org/manual/)
 

--- a/lua.html.markdown
+++ b/lua.html.markdown
@@ -401,7 +401,7 @@ I started with [BlackBulletIV's Lua for programmers](https://ebens.me/posts/lua-
 Next I read the official [Programming in Lua](http://www.lua.org/pil/contents.html) book.
 That's the how.
 
-It might be helpful to check out the [Lua short reference](http://lua-users.org/wiki/LuaShortReference) on lua-users.org.
+It might be helpful to check out the [Lua short reference](http://lua-users.org/files/wiki_insecure/users/thomasl/luarefv51.pdf) on lua-users.org. Also avilable in [single-column](http://lua-users.org/files/wiki_insecure/users/thomasl/luarefv51single.pdf) format.
 
 The main topics not covered are standard libraries:
 


### PR DESCRIPTION
The en and es-es Lua pages both point to a page on lua-users.org that contains broken links to luarefv51.pdf. The fr-fr version contains a broken link. The other languages contain a different link. I have updated these 3 files to point to the same version the other Lua pages point to.

I attempted to edit lua-users.org but it appears that site is broken. It may be wise to change all lua-users.org links to archive.org links if that website is unmaintained. 

For reference, here is a link to an archive version of [Lua Short Reference](https://web.archive.org/web/20230308171621/https://lua-users.org/wiki/LuaShortReference) page.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!