### PR TITLE
docs: reformat get sources to be a list of alternatives

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -103,11 +103,11 @@ You can build the site locally to test your changes. Follow the steps below.
    * `cd learnxinyminutes-site/`
    * `bundle install`
 * Get the source in place
-   * Copy the contents of your clone of the fork of learnxinyminutes-docs repo
+   * A) Copy the contents of your clone of the fork of learnxinyminutes-docs repo
      into the `source/docs` folder. There shouldn't be a `learnxinyminutes-docs`
      folder inside the `docs` folder, it should just contain all the repo
      contents.
-   * Checkout your fork of the learnxinyminutes-docs repo as `source/docs`.
+   * B) Checkout your fork of the learnxinyminutes-docs repo as `source/docs`.
       * `cd source/docs/`
       * `git clone https://github.com/YOUR-USERNAME/learnxinyminutes-docs ./source/docs/`
 * Build the site or run a development server to test your changes (NOTE: run


### PR DESCRIPTION
Hi,

Formatting could emphasize that these two are alternatives.
<img width="924" alt="Screenshot 2024-10-29 at 13 20 15" src="https://github.com/user-attachments/assets/94ea90cd-32aa-4b1e-b295-af0fdb66aef7">

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
