### PR TITLE
docs: add link as get source alternative

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -103,11 +103,11 @@ You can build the site locally to test your changes. Follow the steps below.
    * `cd learnxinyminutes-site/`
    * `bundle install`
 * Get the source in place
-   * Copy the contents of your clone of the fork of learnxinyminutes-docs repo
+   * A) Copy the contents of your clone of the fork of learnxinyminutes-docs repo
      into the `source/docs` folder. There shouldn't be a `learnxinyminutes-docs`
      folder inside the `docs` folder, it should just contain all the repo
      contents.
-   * Checkout your fork of the learnxinyminutes-docs repo as `source/docs`.
+   * B) Checkout your fork of the learnxinyminutes-docs repo as `source/docs`.
       * `cd source/docs/`
       * `git clone https://github.com/YOUR-USERNAME/learnxinyminutes-docs ./source/docs/`
 * Build the site or run a development server to test your changes (NOTE: run

--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -110,6 +110,9 @@ You can build the site locally to test your changes. Follow the steps below.
    * B) Checkout your fork of the learnxinyminutes-docs repo as `source/docs`.
       * `cd source/docs/`
       * `git clone https://github.com/YOUR-USERNAME/learnxinyminutes-docs ./source/docs/`
+   * C) Link docs repository folder.
+      * `rm ./source/docs`
+      * `ln -s YOUR-PATH/learnxinyminutes-docs ./source/docs`
 * Build the site or run a development server to test your changes (NOTE: run
   these commands at `learnxinyminutes-site/`).
    * Build - `bundle exec middleman build`


### PR DESCRIPTION
On top of https://github.com/adambard/learnxinyminutes-docs/pull/5157
I found out symlink to work nice as it will pick up any changes in docs repo.
Perhaps you want it mentioned in docs?

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!


