### PR TITLE
[fortran/en] declares single precision pi without extraneous digits

### DIFF
--- a/fortran.html.markdown
+++ b/fortran.html.markdown
@@ -41,7 +41,7 @@ program example         ! declare a program called example.
     real :: v, x        ! WARNING: default initial values are compiler dependent!
     real :: a = 3, b = 2E12, c = 0.01
     integer :: i, j, k = 1, m
-    real, parameter :: PI = 3.1415926535897931    ! declare a constant.
+    real, parameter :: PI = 3.14159265            ! declare a constant.
     logical :: y = .TRUE., n = .FALSE.            ! boolean type.
     complex :: w = (0, 1)                         ! sqrt(-1)
     character(len=3) :: month                     ! string of 3 characters.


### PR DESCRIPTION
Addresses https://github.com/adambard/learnxinyminutes-docs/issues/5170.

The previous version had a line

real, parameter :: PI = 3.1415926535897931

that was misleading, since real variables are single precision by default in Fortran and will not store all the digits shown.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [ ] Yes, I have double-checked quotes and field names!
