### PR TITLE
[ruby/en] Reflow comments

### DIFF
--- a/ruby.html.markdown
+++ b/ruby.html.markdown
@@ -259,8 +259,8 @@ else
   'else, also optional'
 end
 
-# If a condition controls invocation of a single statement rather than a block of code
-# you can use postfix-if notation
+# If a condition controls invocation of a single statement rather than a block
+# of code you can use postfix-if notation
 warnings = ['Patronimic is missing', 'Address too short']
 puts("Some warnings occurred:\n" + warnings.join("\n"))  if !warnings.empty?
 
@@ -279,9 +279,10 @@ for counter in 1..5
   puts "iteration #{counter}"
 end
 
-# The `do |variable| ... end` construct above is called a 'block'. Blocks are similar
-# to lambdas, anonymous functions or closures in other programming languages. They can
-# be passed around as objects, called, or attached as methods.
+# The `do |variable| ... end` construct above is called a 'block'. Blocks are
+# similar to lambdas, anonymous functions or closures in other programming
+# languages. They can be passed around as objects, called, or attached as
+# methods.
 #
 # The 'each' method of a range runs the block once for each element of the range.
 # The block is passed a counter as a parameter.
@@ -415,19 +416,20 @@ surround { puts 'hello world' }
 #=> hello world
 #=> }
 
-# Blocks can be converted into a 'proc' object, which wraps the block
-# and allows it to be passed to another method, bound to a different scope,
-# or manipulated otherwise. This is most common in method parameter lists,
-# where you frequently see a trailing '&block' parameter that will accept
-# the block, if one is given, and convert it to a 'Proc'. The naming here is
-# convention; it would work just as well with '&pineapple'.
+# Blocks can be converted into a 'proc' object, which wraps the block and allows
+# it to be passed to another method, bound to a different scope, or manipulated
+# otherwise. This is most common in method parameter lists, where you frequently
+# see a trailing '&block' parameter that will accept the block, if one is given,
+# and convert it to a 'Proc'. The naming here is convention; it would work just
+# as well with '&pineapple'.
 def guests(&block)
   block.class #=> Proc
   block.call(4)
 end
 
 # The 'call' method on the Proc is similar to calling 'yield' when a block is
-# present. The arguments passed to 'call' will be forwarded to the block as arguments.
+# present. The arguments passed to 'call' will be forwarded to the block as
+# arguments.
 
 guests { |n| "You have #{n} guests." }
 # => "You have 4 guests."
@@ -480,9 +482,9 @@ best *ranked_competitors
 5.even? #=> false
 5.odd? #=> true
 
-# By convention, if a method name ends with an exclamation mark, it does something destructive
-# like mutate the receiver. Many methods have a ! version to make a change, and
-# a non-! version to just return a new changed version.
+# By convention, if a method name ends with an exclamation mark, it does
+# something destructive like mutate the receiver. Many methods have a ! version
+# to make a change, and a non-! version to just return a new changed version.
 company_name = "Dunder Mifflin"
 company_name.upcase #=> "DUNDER MIFFLIN"
 company_name #=> "Dunder Mifflin"
@@ -516,7 +518,8 @@ class Human
     @name
   end
 
-  # The above functionality can be encapsulated using the attr_accessor method as follows.
+  # The above functionality can be encapsulated using the attr_accessor method
+  # as follows.
   attr_accessor :name
 
   # Getter/setter methods can also be created individually like this.

--- a/ruby.html.markdown
+++ b/ruby.html.markdown
@@ -91,7 +91,7 @@ false.class #=> FalseClass
 2 <= 2 #=> true
 2 >= 2 #=> true
 
-# Combined comparison operator (returns `1` when the first argument is greater, 
+# Combined comparison operator (returns `1` when the first argument is greater,
 # `-1` when the second argument is greater, and `0` otherwise)
 1 <=> 10 #=> -1 (1 < 10)
 10 <=> 1 #=> 1 (10 > 1)
@@ -268,7 +268,7 @@ puts("Some warnings occurred:\n" + warnings.join("\n"))  if !warnings.empty?
 puts("Some warnings occurred:\n" + warnings.join("\n"))  unless warnings.empty?
 
 # Loops
-# In Ruby, traditional `for` loops aren't very common. Instead, these 
+# In Ruby, traditional `for` loops aren't very common. Instead, these
 # basic loops are implemented using enumerable, which hinges on `each`.
 (1..5).each do |counter|
   puts "iteration #{counter}"
@@ -415,10 +415,10 @@ surround { puts 'hello world' }
 #=> hello world
 #=> }
 
-# Blocks can be converted into a 'proc' object, which wraps the block 
+# Blocks can be converted into a 'proc' object, which wraps the block
 # and allows it to be passed to another method, bound to a different scope,
 # or manipulated otherwise. This is most common in method parameter lists,
-# where you frequently see a trailing '&block' parameter that will accept 
+# where you frequently see a trailing '&block' parameter that will accept
 # the block, if one is given, and convert it to a 'Proc'. The naming here is
 # convention; it would work just as well with '&pineapple'.
 def guests(&block)
@@ -426,7 +426,7 @@ def guests(&block)
   block.call(4)
 end
 
-# The 'call' method on the Proc is similar to calling 'yield' when a block is 
+# The 'call' method on the Proc is similar to calling 'yield' when a block is
 # present. The arguments passed to 'call' will be forwarded to the block as arguments.
 
 guests { |n| "You have #{n} guests." }
@@ -443,7 +443,7 @@ end
 upcased = ['Watch', 'these', 'words', 'get', 'upcased'].map(&:upcase)
 puts upcased
 #=> ["WATCH", "THESE", "WORDS", "GET", "UPCASED"]
- 
+
 sum = [1, 2, 3, 4, 5].reduce(&:+)
 puts sum
 #=> 15
@@ -472,7 +472,7 @@ def best(first, second, third, *others)
   puts "There were #{others.count} other participants."
 end
 
-best *ranked_competitors 
+best *ranked_competitors
 #=> Winners are John, Sally, and Dingus.
 #=> There were 2 other participants.
 


### PR DESCRIPTION
Reflows a bunch of comments that were breaking the Style Guideline of 80 characters.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
