### PR TITLE
[ruby/en] clarify alternate hash syntax

### DIFF
--- a/ruby.html.markdown
+++ b/ruby.html.markdown
@@ -233,11 +233,14 @@ hash['number'] #=> 5
 # Asking a hash for a key that doesn't exist returns nil.
 hash['nothing here'] #=> nil
 
-# When using symbols for keys in a hash, you can use an alternate syntax.
+# When using symbols for keys in a hash, you can use an alternate syntax similar
+# to JavaScript.
 
+# key => value
 hash = { :defcon => 3, :action => true }
 hash.keys #=> [:defcon, :action]
 
+# key: value
 hash = { defcon: 3, action: true }
 hash.keys #=> [:defcon, :action]
 


### PR DESCRIPTION
Notes the difference specifically as `k:v` vs `:k=>v` and adds comments accordingly.

I have not added myself as a contributor in the list as I feel this is not significant enough a contribution.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
