### PR TITLE
[java/en] Fix minor typo

### DIFF
--- a/java.html.markdown
+++ b/java.html.markdown
@@ -225,7 +225,7 @@ public class LearnJava {
         String fooString = "My String Is Here!";
 
         // Text blocks
-        vat textBlock = """
+        var textBlock = """
                         This is a <Text Block> in Java 
                         """;
 


### PR DESCRIPTION
This commit fixes a very minor typo in the `java` (English) tutorial.

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [X] Yes, I have double-checked quotes and field names!
