### PR TITLE
[ocaml/en] Correct OCaml record field assignment syntax

### DIFF
--- a/ocaml.html.markdown
+++ b/ocaml.html.markdown
@@ -341,9 +341,9 @@ type animal =
 ;;
 
 let cow = 
-   {  name: "cow";
-      color: "black and white";
-      legs: 4; 
+   {  name = "cow";
+      color = "black and white";
+      legs = 4; 
    }
 ;;
 val cow : animal
@@ -488,7 +488,7 @@ filter (fun x -> x < 4) [3; 1; 4; 1; 5] ;; (* Gives [3; 1; 1]) *)
 (* However, you can create mutable polymorphic fields *)
 type counter = { mutable num : int } ;;
 
-let c = { num: 0 } ;;
+let c = { num = 0 } ;;
 c.num ;; (* Gives 0 *)
 c.num <- 1 ;; (* <- operator can set mutable record fields *)
 c.num ;; (* Gives 1 *)


### PR DESCRIPTION
Fixed an error in the OCaml article where record field assignments incorrectly used `:` instead of `=`.
Updated example:
```ocaml
let cow = { name = "cow"; color = "brown"; legs = 4 };;
```

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr-fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.markdown)
  - [x] Yes, I have double-checked quotes and field names!
