### PR TITLE
[rust/en] fix typo

### DIFF
--- a/rust.md
+++ b/rust.md
@@ -89,7 +89,7 @@ fn main() {
     let x: &str = "hello world!";
 
     // Printing
-    println!("{} {}", f, x); // 1.3 hello world
+    println!("{} {}", f, x); // 1.3 hello world!
 
     // A `String` – a heap-allocated string
     // Stored as a `Vec<u8>` and always holds a valid UTF-8 sequence, 


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)