### PR TITLE
[nim/en] Fixed instantiation of the reference object

### DIFF
--- a/nim.md
+++ b/nim.md
@@ -129,8 +129,11 @@ type
 
 var
   defaultHouse = House() # initialize with default values
-  defaultRoom = new Room() # create new instance of ref object
-  sesameHouse = House(address: "123 Sesame St.", rooms: @[defaultRoom])
+  defaultRoom = Room() # create new instance of ref object with default values
+
+  # Create and initialize instances with given values
+  sesameRoom = Room(windows: 4, doors: 2)
+  sesameHouse = House(address: "123 Sesame St.", rooms: @[sesameRoom])
 
 # Enumerations allow a type to have one of a limited number of values
 


### PR DESCRIPTION
Fixed wrong instantiation of the reference object `Room`.

While using `var defaultRoom = new Room` instead of `var defaultRoom = new Room()` is also valid, I opted to use the preferred syntax `var defaultRoom = Room()`

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` or `[java/en]`)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
