### PR TITLE
[zig] Addressing wrong type for the pointer example 

### DIFF
--- a/zig.md
+++ b/zig.md
@@ -204,7 +204,7 @@ const slice = array[0..array.len];  // "slice" represents the whole array.
 ```zig
 // Pointer on a value can be created with "&".
 const x: i32 = 1;
-const pointer: *i32 = &x;  // "pointer" is a pointer on the i32 var "x".
+const pointer: *const i32 = &x;  // "pointer" is a pointer on the const i32 var "x".
 print("1 = {}, {}\n", .{x, pointer});
 
 // Pointer values are accessed and modified with ".*".


### PR DESCRIPTION
The pointer needs to be *const i32 since x is const i32.

The other option would be to change x from const to var:

```
var x: i32 =1;
const pointer: *i32 = &x
```