### PR TITLE
javascript/en

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -646,13 +646,13 @@ of the language.
 
 [JavaScript: The Definitive Guide][6] is a classic guide and reference book.
 
-[Eloquent JavaScript][8] by Marijn Haverbeke is an excellent JS book/ebook with
+[Eloquent JavaScript][http://eloquentjavascript.net/] by Marijn Haverbeke is an excellent JS book/ebook with
 attached terminal
 
-[JavaScript: The Right Way][10] is a guide intended to introduce new developers
+[JavaScript: The Right Way][http://jstherightway.org/] is a guide intended to introduce new developers
 to JavaScript and help experienced developers learn more about its best practices.
 
-[javascript.info][11] is a modern JavaScript tutorial covering the basics (core language and working with a browser)
+[javascript.info][https://javascript.info/] is a modern JavaScript tutorial covering the basics (core language and working with a browser)
 as well as advanced topics with concise explanations.
 
 
@@ -668,6 +668,3 @@ Mozilla Developer Network.
 [6]: http://www.amazon.com/gp/product/0596805527/
 [7]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript
 [8]: https://www.javascripttutorial.net/
-[8]: http://eloquentjavascript.net/
-[10]: http://jstherightway.org/
-[11]: https://javascript.info/


### PR DESCRIPTION
Links in English JavaScript document got off so affected links are replaced with direct ones instead of footnotes

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
