### PR TITLE
[bash/en] Fix semantic misleading in description.

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -231,7 +231,7 @@ ls -t # Sorts the directory contents by last-modified date (descending)
 ls -R # Recursively `ls` this directory and all of its subdirectories
 
 # Results (stdout) of the previous command can be passed as input (stdin) to the next command
-# using a pipe |. Commands chained in this way are called a "pipeline", and are run concurrently.
+# using a pipe |. Commands chained in this way are called a "pipeline", and are run sequentially.
 # The `grep` command filters the input with provided patterns.
 # That's how we can list .txt files in the current directory:
 ls -l | grep "\.txt"


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)

---

Hello! I believe that there is a misleading in the description of how `|` pipe sign works in bash. In the case below:

```bash
ls -l | grep "\.txt"
```

The `grep` command starts processing the output of  `ls -l` commands as soon as `ls -l` begins producing it. I believe that it's more clear especially for those who just begin they journey in bash to say that the commands are run sequentially.  
