### PR TITLE
[csv/en] Fix incorrect front matter name

### DIFF
--- a/csv.md
+++ b/csv.md
@@ -1,5 +1,5 @@
 ---
-language: CSV
+name: CSV
 contributors:
 - [Timon Erhart, 'https://github.com/turbotimon/']
 ---


### PR DESCRIPTION
The CSV page used the wrong front matter, which caused CI failures starting in 49be924382b896a33c8cea97ddd07454a23fd5f9.
    
"language" should be "name".

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)