### PR TITLE
[Smalltalk/en] Fix broken link on smalltalk page

### DIFF
--- a/smalltalk.md
+++ b/smalltalk.md
@@ -1030,7 +1030,7 @@ Most Smalltalks are either free as in OSS or have a free downloadable version wi
 * [VisualWorks Smalltalk](http://www.cincomsmalltalk.com/)
 
 ### Online Smalltalk books and articles
-* [Smalltalk Programming Resources](http://www.whoishostingthis.com/resources/smalltalk/)
+* [Smalltalk Programming Resources](https://cybernewsguide.com/resources/smalltalk/)
 * [Smalltalk Cheatsheet](http://www.angelfire.com/tx4/cus/notes/smalltalk.html)
 * [Smalltalk-72 Manual](http://www.bitsavers.org/pdf/xerox/parc/techReports/Smalltalk-72_Instruction_Manual_Mar76.pdf)
 * [GNU Smalltalk User's Guide](https://www.gnu.org/software/smalltalk/manual/html_node/Tutorial.html)


### PR DESCRIPTION
Fixes issue #4622 

I updated the "Smalltalk Programming Resources" link.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
