### PR TITLE
[python/es] Multiline string as documentation

### DIFF
--- a/es/python.md
+++ b/es/python.md
@@ -14,7 +14,7 @@ Es básicamente pseudocódigo ejecutable.
 
 """ Strings multilinea pueden escribirse
     usando tres "'s, y comunmente son usados
-    como comentarios.
+    como documentación.
 """
 
 ####################################################


### PR DESCRIPTION
The multiline string is used as documentation and the original post refers it as documentation and not only comments

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
