### PR TITLE
[ruby/en] Update error output in ruby.md

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -118,7 +118,7 @@ placeholder = 'use string interpolation'
 
 # You can combine strings using `+`, but not with other types
 'hello ' + 'world'  #=> "hello world"
-'hello ' + 3 #=> TypeError: can't convert Fixnum into String
+'hello ' + 3 #=> TypeError: no implicit conversion of Integer into String
 'hello ' + 3.to_s #=> "hello 3"
 "hello #{3}" #=> "hello 3"
 


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)

Current error output references Fixnum which was removed from Ruby. This pull request shows the error message as given in irb and pry as shown below (ruby 3.4.4)

```
irb(main):001> 'hello ' + 3
(irb):1:in 'String#+': no implicit conversion of Integer into String (TypeError)
	from (irb):1:in '<main>'
	from <internal:kernel>:168:in 'Kernel#loop'
	from /home/hoser/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/irb-1.15.2/exe/irb:9:in '<top (required)>'
	from /home/hoser/.local/share/mise/installs/ruby/3.4.4/bin/irb:25:in 'Kernel#load'
	from /home/hoser/.local/share/mise/installs/ruby/3.4.4/bin/irb:25:in '<main>'
irb(main):002>
```

```
[1] pry(main)> "hello " + 3
TypeError: no implicit conversion of Integer into String (TypeError)
from (pry):1:in 'String#+'
[2] pry(main)> 
```