### PR TITLE
[python/en] Fix @wraps decorator example

### DIFF
--- a/python.md
+++ b/python.md
@@ -1061,6 +1061,7 @@ def log_function(func):
 
 @log_function               # equivalent:
 def my_function(x,y):       # def my_function(x,y):
+    """Adds two numbers together."""
     return x+y              #   return x+y
                             # my_function = log_function(my_function)
 # The decorator @log_function tells us as we begin reading the function definition
@@ -1076,7 +1077,7 @@ my_function(1,2)  # => "Entering function my_function"
 # What happens if we try to get some information about my_function?
 
 print(my_function.__name__)  # => 'wrapper'
-print(my_function.__code__.co_argcount)  # => 0. The argcount is 0 because both arguments in wrapper()'s signature are optional.
+print(my_function.__doc__)  # => None (wrapper function has no docstring)
 
 # Because our decorator is equivalent to my_function = log_function(my_function)
 # we've replaced information about my_function with information from wrapper
@@ -1097,6 +1098,7 @@ def log_function(func):
 
 @log_function
 def my_function(x,y):
+    """Adds two numbers together."""
     return x+y
 
 my_function(1,2)  # => "Entering function my_function"
@@ -1104,7 +1106,7 @@ my_function(1,2)  # => "Entering function my_function"
                   # => "Exiting function my_function"
 
 print(my_function.__name__)  # => 'my_function'
-print(my_function.__code__.co_argcount)  # => 2
+print(my_function.__doc__)  # => 'Adds two numbers together.'
 ```
 
 ### Free Online


### PR DESCRIPTION
Relevant issue: https://github.com/adambard/learnxinyminutes-docs/issues/5347

The `__code__` example doesn't work as described but the `__doc__` does so I added a docstring and replaced the use of `__code__` with `__doc__`.

I also find it a little simpler. 

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
