### PR TITLE
[lua/en] Fix awkward wording in English Lua documentation 

### DIFF
--- a/lua.md
+++ b/lua.md
@@ -232,8 +232,8 @@ eatenBy = myFavs.animal  -- works! thanks, metatable
 -- An __index value can also be a function(tbl, key)
 -- for more customized lookups.
 
--- Values of __index,add, .. are called metamethods.
--- Full list. Here a is a table with the metamethod.
+-- The values of __index, __add, etc. are called
+-- metamethods. Here are some commonly used ones:
 
 -- __add(a, b)                     for a + b
 -- __sub(a, b)                     for a - b


### PR DESCRIPTION
In addition, the cited list of metamethods isn't exhaustive.

A detailed list of operations controlled by metatables is available at: https://www.lua.org/manual/5.4/manual.html#2.4

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)