### PR TITLE
[bash/en] fix inaccurate description re `[[ ... && ... || ... ]]` and examples to match it; change while to use `[[ ... ]]` for consistency

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -166,13 +166,13 @@ else
     echo "Your name is your username"
 fi
 
-# To use && and || with if statements, you need multiple pairs of square brackets:
+# You can use && and || with if statements:
 read age
-if [[ "$name" == "Steve" ]] && [[ "$age" -eq 15 ]]; then
+if [[ "$name" == "Steve" && "$age" -eq 15 ]]; then
     echo "This will run if $name is Steve AND $age is 15."
 fi
 
-if [[ "$name" == "Daniya" ]] || [[ "$name" == "Zach" ]]; then
+if [[ "$name" == "Daniya" || "$name" == "Zach" ]]; then
     echo "This will run if $name is Daniya OR Zach."
 fi
 

--- a/bash.md
+++ b/bash.md
@@ -411,7 +411,7 @@ do
 done
 
 # while loop:
-while [ true ]
+while [[ true ]]
 do
     echo "loop body here..."
     break


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
