### PR TITLE
[toml/en] Fix key typo

### DIFF
--- a/toml.md
+++ b/toml.md
@@ -32,7 +32,7 @@ dateTime = 1979-05-27T07:32:00-08:00
 scientificNotation = 1e+12
 "key can be quoted" = true # Both " and ' are fine
 "unquoted key may contain" = "letters, numbers, underscores, and dashes"
-other_kêys = "are permitted by spec but most implementations don't actually permit them"
+other_keys = "are permitted by spec but most implementations don't actually permit them"
 
 # A bare key must be non-empty, but an empty quoted key is allowed
 "" = "blank"     # VALID but discouraged


### PR DESCRIPTION
Hi. My OCD forced me to make this PR, because I noticed a TOML key named `other_kêys` which made it look strange in the web page. So I changed it to `other_keys` instead.

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)