### PR TITLE
[haskell]: fix learnyouahaskell link 404 error

### DIFF
--- a/de/haskell.md
+++ b/de/haskell.md
@@ -437,5 +437,5 @@ Haskell ist sehr einfach zu installieren.
 Hol es dir von [hier](http://www.haskell.org/platform/).
 
 Eine sehr viele langsamere Einführung findest du unter:
-[Learn you a Haskell](http://learnyouahaskell.com/) oder
+[Learn you a Haskell](https://learnyouahaskell.github.io/) oder
 [Real World Haskell](http://book.realworldhaskell.org/).

--- a/el/haskell.md
+++ b/el/haskell.md
@@ -468,6 +468,6 @@ qsort (p:xs) = qsort lesser ++ [p] ++ qsort greater
 - [Stack-based process](https://www.stackage.org/install).
 
 Στις παρακάτω πηγές μπορείτε να βρείτε αρκετά κομψές εισαγωγές στην Haskell
-- [Learn you a Haskell](http://learnyouahaskell.com/),
+- [Learn you a Haskell](https://learnyouahaskell.github.io/),
 - [Happy Learn Haskell Tutorial](http://www.happylearnhaskelltutorial.com/),
 - [Real World Haskell](http://book.realworldhaskell.org/)

--- a/es/haskell.md
+++ b/es/haskell.md
@@ -429,6 +429,6 @@ qsort (p:xs) = qsort lesser ++ [p] ++ qsort greater
 Haskell es fácil de instalar. Obtenlo [aquí](http://www.haskell.org/platform/).
 
 Usted puede encontrar más información en:
-[Learn you a Haskell](http://learnyouahaskell.com/) o
+[Learn you a Haskell](https://learnyouahaskell.github.io/) o
 [Real World Haskell](http://book.realworldhaskell.org/) o
 [Aprende Haskell por el bien de todos](http://aprendehaskell.es/)

--- a/pl/haskell.md
+++ b/pl/haskell.md
@@ -441,5 +441,5 @@ Haskell może zostać zainstalowany na co najmniej dwa sposoby:
  - nowocześnie [z pomocą Stack](https://www.stackage.org/install).
 
 Godnymi poleceniami wprowadzeniami są wspaniałe
-[Learn you a Haskell](http://learnyouahaskell.com/) albo
+[Learn you a Haskell](https://learnyouahaskell.github.io/) albo
 [Real World Haskell](http://book.realworldhaskell.org/).

--- a/ro/haskell.md
+++ b/ro/haskell.md
@@ -449,5 +449,5 @@ qsort (p:xs) = qsort lesser ++ [p] ++ qsort greater
 Există două maniere populare de a instala Haskell: prin [instalarea bazată pe Cabal](http://www.haskell.org/platform/), și prin mai noul [proces bazat pe Stack](https://www.stackage.org/install).
 
 Se poate găsi o introducere în Haskell mult mai blândă la adresele
-[Learn you a Haskell](http://learnyouahaskell.com/) sau
+[Learn you a Haskell](https://learnyouahaskell.github.io/) sau
 [Real World Haskell](http://book.realworldhaskell.org/).

--- a/ru/haskell.md
+++ b/ru/haskell.md
@@ -538,7 +538,7 @@ qsort (p:xs) = qsort lesser ++ [p] ++ qsort greater
 Haskell прост в установке, забирайте [здесь](http://www.haskell.org/platform/) и пробуйте! Это же так интересно!.
 
 Более глубокое погрузиться в язык позволят прекрасные книги
-[Learn you a Haskell](http://learnyouahaskell.com/) и
+[Learn you a Haskell](https://learnyouahaskell.github.io/) и
 [Real World Haskell](http://book.realworldhaskell.org/).
 
 [author]: http://adit.io "имеется в виду автор оригинального текста Adit Bhargava *(примечание переводчика)*"

--- a/sv/haskell.md
+++ b/sv/haskell.md
@@ -452,6 +452,6 @@ Det finns två populära sätt att installera Haskell på: Den traditionella [Ca
 
 Du kan finna vänligare och/eller djupare introduktioner till Haskell på engelska
 från:
-[Learn you a Haskell](http://learnyouahaskell.com/),
+[Learn you a Haskell](https://learnyouahaskell.github.io/),
 [Happy Learn Haskell Tutorial](http://www.happylearnhaskelltutorial.com/) eller
 [Real World Haskell](http://book.realworldhaskell.org/).

--- a/zh-cn/haskell.md
+++ b/zh-cn/haskell.md
@@ -392,6 +392,6 @@ qsort (p:xs) = qsort lesser ++ [p] ++ qsort greater
 安装 Haskell 很简单。你可以[从这里获得](http://www.haskell.org/platform/)。
 
 你可以从优秀的
-[Learn you a Haskell](http://learnyouahaskell.com/) 或者
+[Learn you a Haskell](https://learnyouahaskell.github.io/) 或者
 [Real World Haskell](http://book.realworldhaskell.org/)
 找到更平缓的入门介绍。


### PR DESCRIPTION
[learnyouahaskell.com](http://learnyouahaskell.com/) is no longer accessible. How about replacing it with the community open-source version at https://learnyouahaskell.github.io/?

---

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
