### PR TITLE
[hcl/en] `joined_list` uses `prefixed_list`

### DIFF
--- a/hcl.md
+++ b/hcl.md
@@ -8,7 +8,7 @@ filename: terraform.txt
 ## Introduction
 
 HCL (Hashicorp Configuration Language) is a high-level configuration language used in tools from
-Hashicorp (such as Terraform). HCL/Terraform is widely used in provisioning cloud infastructure and
+Hashicorp (such as Terraform). HCL/Terraform is widely used in provisioning cloud infrastructure and
 configuring platforms/services through APIs. This document focuses on HCL 0.13 syntax.
 
 HCL is a declarative language and Terraform will consume all `*.tf` files in the current folder, so code
@@ -26,7 +26,7 @@ variable "ready" {
 }
 
 // Module block consults a specified folder for *.tf files, would
-// effectively prefix all resources IDs with "module.learn-basics."
+// effectively prefix all resource IDs with "module.learn-basics."
 module "learn-basics" {
   source = "./learn-basics"
   ready_to_learn = var.ready
@@ -128,7 +128,7 @@ for managing AWS cloud resources.
 When `terraform` is invoked (`terraform apply`) it will validate code, create all resources
 in memory, load their existing state from a file (state file), refresh against the current
 cloud APIs and then calculate the differences. Based on the differences, Terraform proposes
-a "plan" - series of create, modify or delete actions to bring your infrastructrue in
+a "plan" - series of create, modify or delete actions to bring your infrastructure in
 alignment with an HCL definition.
 
 Terraform will also automatically calculate dependencies between resources and will maintain
@@ -285,7 +285,7 @@ locals {
 
   prefixed_list = [for v in local.filtered_list : "pre-${v}" ] // "pre-ON", "pre-TH"
 
-  joined_list = join(local.upper_list,local. filtered_list) // "ONE", "TWO", "THREE", "pre-ON", "pre-TH"
+  joined_list = join(local.upper_list, local.prefixed_list) // "ONE", "TWO", "THREE", "pre-ON", "pre-TH"
 
   // Set is very similar to List, but element order is irrelevant
   joined_set = toset(local.joined_list) // "ONE", "TWO", "THREE", "pre-ON", "pre-TH"


### PR DESCRIPTION
The docs previously showed `joined_list` as being constructed using `filtered_list`, which would not preduce the described output.

Also fixed some typos: "infrastructure" is hard to spell :P

- [X] I solemnly swear that this is all original content of which I am the original author
- [X] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
