### PR TITLE
[ruby/en] Replace double negation with simple negation

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -80,10 +80,10 @@ false.class #=> FalseClass
 
 # Apart from false itself, nil is the only other 'falsey' value
 
-!!nil   #=> false
-!!false #=> false
-!!0     #=> true
-!!""    #=> true
+!nil   #=> true
+!false #=> true
+!0     #=> false
+!""    #=> false
 
 # More comparisons
 1 < 10 #=> true


### PR DESCRIPTION
This change is mainly to decrease the cognitive load of reading the document. 

There is no need to use double negation in this example; it may get people confused about the syntax of simple negation and demand them to look at the comment to figure out that is is a double negation.

- [X] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [X] Pull request touches only one file (or a set of logically related files with similar changes made)
- [X] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [X] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
