### PR TITLE
[mongodb/en] Fix logical operator syntax errors in examples

### DIFF
--- a/mongodb.md
+++ b/mongodb.md
@@ -3,6 +3,7 @@ name: MongoDB
 filename: mongo.js 
 contributors:
   - ["Raj Piskala", "https://www.rajpiskala.ml/"]
+  - ["Manprit Tiwari", "https://github.com/manprit-tiwari"]
 ---
 
 MongoDB is a NoSQL document database for high volume data storage.
@@ -272,33 +273,33 @@ db.engineers.find({ age: { $nin: [ 20, 23, 24, 25 ]}})
 
 // Join two query clauses together
 // NOTE: MongoDB does this implicitly for most queries
-db.engineers.find({ $and: [
-  gender: 'Female',
-  age: {
-    $gte: 18
-  }
-]})
+db.engineers.find({
+  $and: [
+    { gender: 'Female' },
+    { age: { $gte: 18 } }
+  ]
+})
 
 // Match either query condition
-db.engineers.find({ $or: [
-  gender: 'Female',
-  age: {
-    $gte: 18
-  }
-]})
+db.engineers.find({
+  $or: [
+    { gender: 'Female' },
+    { age: { $gte: 18 } }
+  ]
+})
 
 // Negates the query
-db.engineers.find({ $not: {
-  gender: 'Female'
-}})
+db.engineers.find({
+  gender: { $not: { $eq: 'Female' } }
+})
 
 // Must match none of the query conditions
-db.engineers.find({ $nor [
-  gender: 'Female',
-  age: {
-    $gte: 18
-  }
-]})
+db.engineers.find({
+  $nor: [
+    { gender: 'Female' },
+    { age: { $gte: 18 } }
+  ]
+})
 
 /////////////////////////////////////////////////////////
 //////////////// Database Operations: ///////////////////


### PR DESCRIPTION
This PR fixes incorrect MongoDB logical operator examples in the documentation.

**Changes made:**
- Corrected `$and`, `$or`, and `$nor` syntax (added proper object wrapping `{}`).
- Fixed `$not` example to use field-level condition.
- Verified all queries run correctly in MongoDB shell.

These corrections improve accuracy and help new learners avoid confusion.

---

### Checklist
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[mongodb/en]`
- [x] Pull request touches only one file (`mongodb.md`)
- [x] Content changes are aimed at intermediate to experienced programmers
- [x] YAML Frontmatter formatting verified