### PR TITLE
[dart/zh-cn]: Example23 class When used as a mixin, it throws an error.

### DIFF
--- a/zh-cn/dart.md
+++ b/zh-cn/dart.md
@@ -327,8 +327,9 @@ example22() {
 // Mixin 主要是用来和辅助的类共享方法的，
 // 这样单一继承就不会影响代码复用。
 // Mixin 声明在类定义的 "with" 关键词后面。
+// 在 Dart 2.1 之前：把一个普通的、没有构造函数的 class 当作 mixin 使用。新项目推荐使用 mixin
 class Example23A {}
-class Example23Utils {
+mixin Example23Utils {
   addTwo(n1, n2) {
     return n1 + n2;
   }


### PR DESCRIPTION
Before Dart 2.1: Use a regular class without a constructor as a mixin. It is recommended to use mixin for the new project

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
