### PR TITLE
Update python.md

### DIFF
--- a/python.md
+++ b/python.md
@@ -218,7 +218,7 @@ li[4]  # Raises an IndexError
 # You can look at ranges with slice syntax.
 # The start index is included, the end index is not
 # (It's a closed/open range for you mathy types.)
-li[1:3]   # Return list from index 1 to 3 => [2, 4]
+li[1:3]   # Return list from index 1 to 2 => [2, 4]
 li[2:]    # Return list starting from index 2 => [4, 3]
 li[:3]    # Return list from beginning until index 3  => [1, 2, 4]
 li[::2]   # Return list selecting elements with a step size of 2 => [1, 4]


### PR DESCRIPTION
indexing was wrong
the list returned from index 1 to 2 but it was written 1 to 3 which is wrong and confusing as its written just in the line above that the beginning index is included while the ending index is excluded.


- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[python/eng]`
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
