### PR TITLE
[bash/en] add background job wait example

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -18,6 +18,7 @@ contributors:
     - ["Martin Nicholson", "https://github.com/mn113"]
     - ["Mark Grimwood", "https://github.com/MarkGrimwood"]
     - ["Emily Grace Seville", "https://github.com/EmilySeville7cfg"]
+    - ["Denis Borchev", "https://github.com/askbow"]
 filename: LearnBash.sh
 translators:
     - ["Dimitri Kokkonis", "https://github.com/kokkonisd"]
@@ -212,7 +213,14 @@ fg
 bg
 # Kill job number 2
 kill %2
-# %1, %2, etc. can be used for fg and bg as well
+# %1, %2, etc. can be used for fg, bg, and wait as well
+# Wait for job number 3 completion, returns job status code
+wait %3 ; echo $?
+# Wait for all background jobs to complete
+for i in {1..5} ; do sleep 30 &  done ; wait
+# [1] 1718
+# ...
+# [5]   Done                    sleep 30
 
 # Redefine command `ping` as alias to send only 5 packets
 alias ping='ping -c 5'


### PR DESCRIPTION
A typical code pattern for me has been to start a bunch of arbitrary-long-running jobs in parallel (e.g. `curl` to an API endpoint) and wait for their completion. While there are other ways to do it, bash's own background job and `wait` mechanism is easy to work with.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
