### PR TITLE
[ReScript/en] Fix comment on labeled arguments usage

### DIFF
--- a/rescript.md
+++ b/rescript.md
@@ -292,7 +292,7 @@ moveTo(~x=7.0, ~y=3.5)
 let getMessage = (~message as msg) => "==" ++ msg ++ "=="
 
 getMessage(~message="You have a message!")
-/* - The caller specifies ~message but internally the function can make use */
+/* - The caller specifies ~message but internally the function can make use of msg */
 
 /* The following function also has explicit types declared */
 let showDialog = (~message: string): unit => {


### PR DESCRIPTION
Corrected comment typo to clarify the use of labeled arguments.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
