### PR TITLE
[Go/zh-cn] Update the Simple Chinese Version of Golang

### DIFF
--- a/zh-cn/go.md
+++ b/zh-cn/go.md
@@ -331,7 +331,7 @@ func inc(i int, c chan int) {
 
 // 我们将用inc函数来并发地增加一些数字。
 func learnConcurrency() {
-    // 用make来声明一个slice，make会分配和初始化slice，map和channel。
+    // 像前面的例子中用make来初始化一个slice一样，make会分配和初始化slice，map和channel。
     c := make(chan int)
     // 用go关键字开始三个并发的goroutine，如果机器支持的话，还可能是并行执行。
     // 三个都被发送到同一个channel。

--- a/zh-cn/go.md
+++ b/zh-cn/go.md
@@ -281,7 +281,7 @@ func learnInterfaces() {
     p := pair{3, 4}
     fmt.Println(p.String()) // 调用pair类型p的String方法
     var i Stringer          // 声明i为Stringer接口类型
-    i = p                   // 有效！因为p实现了Stringer接口
+    i = p                   // 有效！因为p实现了Stringer接口（类似java中的类型转换）
     // 调用i的String方法，输出和上面一样
     fmt.Println(i.String())
 

--- a/zh-cn/go.md
+++ b/zh-cn/go.md
@@ -281,7 +281,7 @@ func learnInterfaces() {
     p := pair{3, 4}
     fmt.Println(p.String()) // 调用pair类型p的String方法
     var i Stringer          // 声明i为Stringer接口类型
-    i = p                   // 有效！因为p实现了Stringer接口（类似java中的塑型）
+    i = p                   // 有效！因为p实现了Stringer接口
     // 调用i的String方法，输出和上面一样
     fmt.Println(i.String())
 

--- a/zh-cn/go.md
+++ b/zh-cn/go.md
@@ -286,7 +286,7 @@ func learnInterfaces() {
     fmt.Println(i.String())
 
     // fmt包中的Println函数向对象要它们的string输出，实现了String方法就可以这样使用了。
-    // （类似java中的序列化）
+    // （类似java中的 toString() ）
     fmt.Println(p) // 输出和上面一样，自动调用String函数。
     fmt.Println(i) // 输出和上面一样。
 


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)

## Description of the changes

- Remove an analogy of Java
  - The original content is `类似java中的塑型`, which means `similar to 塑形 in java`. But there is no terminology called `塑形` in Java.
- Correct an analogy of Java
  - The original content is `类似java中的序列化`, which means `similar to serialization in java`. But `serialization` is a very abstract and more complex concept. The `toString()` method in Java is closer to the example `String()`.
- Fix a wrong translation
  - The original translation `用make来声明一个slice` means `use make to declare a slice`. This doesn't explain the example correctly and is not the same with the English version `Same make function used earlier to make a slice`.
  - The new translation means `Initialize a slice with make as in the previous example`, which removes ambiguity.