### PR TITLE
[c/en] Fix typo in comp.lang.c FAQ reference

### DIFF
--- a/c.md
+++ b/c.md
@@ -905,7 +905,7 @@ inaccuracies (well, ideas that are not considered good anymore) or now-changed p
 
 Another good resource is [Learn C The Hard Way](http://learncodethehardway.org/c/) (not free).
 
-If you have a question, read the [compl.lang.c Frequently Asked Questions](http://c-faq.com).
+If you have a question, read the [comp.lang.c Frequently Asked Questions](http://c-faq.com).
 
 It's very important to use proper spacing, indentation and to be consistent with your coding style in general.
 Readable code is better than clever code and fast code. For a good, sane coding style to adopt, see the


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
This pull request makes a minor correction to a resource link in the `c.md` documentation file.

* Fixed a typo in the name of the "comp.lang.c Frequently Asked Questions" resource link.