### PR TITLE
[rust/en] Update borrow example for NLL

### DIFF
--- a/rust.md
+++ b/rust.md
@@ -321,7 +321,7 @@ fn main() {
     // Reference – an immutable pointer that refers to other data
     // When a reference is taken to a value, we say that the value has been ‘borrowed’.
     // While a value is borrowed immutably, it cannot be mutated or moved.
-    // A borrow is active until the last use of the reference.
+    // A borrow lasts from where it's created until its last use (Non-Lexical Lifetimes).
     let mut var = 4;
     var = 3;
     let ref_var: &i32 = &var;
@@ -330,7 +330,7 @@ fn main() {
     println!("{}", *ref_var);
     // *ref_var = 6; // this would not compile, because `ref_var` is an immutable reference
     
-    // After the last use of `ref_var` above, the borrow ends (NLL), so this reassignment is allowed.
+    // After the last use of `ref_var` above, the borrow ends, so this reassignment is allowed.
     var = 2;
 
     // Mutable reference
@@ -342,7 +342,7 @@ fn main() {
     println!("{}", *ref_var2); // 6 
     // ref_var2 is of type &mut i32, so stores a reference to an i32, not the value.
     
-    // After the last use of `ref_var2` above, the borrow ends (NLL), so this reassignment is allowed.
+    // After the last use of `ref_var2` above, the borrow ends, so this reassignment is allowed.
     var2 = 2;
 }
 ```


### PR DESCRIPTION
The "Memory safety & pointers" section currently includes a `ref_var;` no-op line and comments that reflect pre-NLL borrow checker behavior.

In modern Rust (NLL stable since 2018), borrows end at the last actual use of the reference, not at the end of the scope.

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
