### PR TITLE
[zig] fix arrays iterations with indexes

### DIFF
--- a/zig.md
+++ b/zig.md
@@ -21,7 +21,7 @@ recommended.
   - The type system distinguishes between a pointer to a single value, or multiple values, etc.
   - Slices are preferred, which is a structure with a pointer and a runtime known size, which characterizes most uses of pointers in the first place.
 - Some arbitrary language limitations are removed. For example, enumerations, structures and unions can have functions.
-- Simple access to SIMD operations (basic maths on vectors).
+- Simple access to SIMD operations (basic math on vectors).
 - Zig provides both low-level features of C and the one provided through compiler extensions.
   For example: packed structures.
 - An extensive standard library, including data structures and algorithms.
@@ -85,7 +85,7 @@ var myvar: u10 = 5; // 10-bit unsigned integer
 const one_billion = 1_000_000_000;         // Decimal.
 const binary_mask = 0b1_1111_1111;         // Binary. Ex: network mask.
 const permissions = 0o7_5_5;               // Octal.  Ex: Unix permissions.
-const big_address = 0xFF80_0000_0000_0000; // Hexa.   Ex: IPv6 address.
+const big_address = 0xFF80_0000_0000_0000; // Hex.    Ex: IPv6 address.
 
 
 // Overflow operators: tell the compiler when it's okay to overflow.


### PR DESCRIPTION
fix for loops with indexes and pointers, commit messages have detailed info:

    [zig] fix arrays iterations with indexes
    
    the syntax `for (array) | value, i | {}` gives compile time error
    for an extra capture group
    
    you need to add another iterable like 0.. for this to work
    
    also added a simple for loop over multiple iterables
    to demostrate this
    ---
    [zig] fix array iteration with pointers
    
    this syntax iterates over an array of pointers
    ```
    for (items) |*value| {}
    ```
    and crashes if you iterate over a normal array like [_]i32
    
    to capture a pointer to an array item itself, this is correct:
    ```
    var items = [_]i32{...};
    for (&items) |*value| {}
    ```


- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md). i didn't
