### PR TITLE
[java] Add real-world Java ecosystem and project references section

### DIFF
--- a/java.md
+++ b/java.md
@@ -1064,3 +1064,15 @@ The links provided here below are just to get an understanding of the topic, fee
 * [Thinking in Java](https://www.amazon.com/Thinking-Java-4th-Bruce-Eckel/dp/0131872486/)
 * [Objects First with Java](https://www.amazon.com/Objects-First-Java-Practical-Introduction/dp/0132492660)
 * [Java The Complete Reference](https://www.amazon.com/gp/product/0071606300)
+
+### Real-World Java Ecosystem & Project References
+
+For developers looking to deepen their practical Java expertise beyond syntax and language fundamentals, the following curated resources provide real-world application architectures, framework usage, and ecosystem-level tooling examples:
+
+* [Awesome Java Applications](https://github.com/akullpp/awesome-java)
+* [Spring Boot Guides](https://spring.io/guides)
+* [OpenJFX Official Documentation](https://openjfx.io/openjfx-docs/)
+* [Java Design Patterns](https://github.com/iluwatar/java-design-patterns)
+* [Java Project Collections (Curated)](https://www.javatpoint.com/java-projects)
+
+These resources emphasize applied architecture, design patterns, frameworks, and ecosystem-level development practices.


### PR DESCRIPTION
Added a new section titled "Real-World Java Ecosystem & Project References" to provide curated links for developers seeking deeper practical exposure beyond core language syntax.

The added resources focus on applied architecture, design patterns, frameworks (e.g., Spring), and ecosystem-level tooling relevant to intermediate and experienced Java developers.

This change does not modify existing explanations and only extends the resource section to improve practical learning references.
