### PR TITLE
[zig/en] Fixed a missleading "for loop" code example for zig

### DIFF
--- a/zig.md
+++ b/zig.md
@@ -378,12 +378,25 @@ for (items) |value| {
 // Similar to while loops, when you break from a for loop,
 // the else branch is not evaluated.
 var sum: i32 = 0;
-// The "for" loop has to provide a value, which will be the "else" value.
+// The "for" loop has to provide a value,
+// which will be the "else" value in this case.
 const result = for (items) |value| {
-    if (value != null) {
-        sum += value.?; // "result" will be the last "sum" value.
+    // Add "value" to "sum" if it's not "null", otherwise add 0
+    sum += value orelse 0;
+} else 0; // result == 0
+
+
+// To set "result" to the value of "sum",
+// break it out of the loop at the last iteration.
+const result = for (items, 1..) |value, i| {
+    sum += value orelse 0;
+
+    // Check if we are at the last iteration
+    if (i == items.len) {
+        // Break value out of the loop
+        break sum; // result == sum
     }
-} else 0;                  // Last value.
+} else unreachable;
 ```
 
 ### Labels.


### PR DESCRIPTION
I found the previous example missleading for these several reasons:
First, the contradiction:
```zig
// The "for" loop has to provide a value, which will be the "else" value. => True in the current example
const result = for (items) |value| {
    if (value != null) {
        sum += value.?; // "result" will be the last "sum" value. => False, and contradicts the previous comment
    }
} else 0;                  // Last value. => Bad formatting + what does "Last value" even mean?
```
Second, the use of "optional raise" operator after checking for null
```zig
const result = for (items) |value| {
    if (value != null) {
        // Have the previous author intended to show that it will never error out after checking for null?
        // This might be very subjective, but I also found this a bit missleading, and I believe that my
        // example with "sum += value orelse 0;" fits the case better and is less confusing, although this is
        // up for debate
        sum += value.?;
    }
} else 0;
```

To verify that my solution is working, you can run it yourself at zig playground: https://zig.fly.dev/p/mmOKhXk2E3c
