### PR TITLE
Remove unnecessary consecutive empty lines in csharp.md

### DIFF
--- a/csharp.md
+++ b/csharp.md
@@ -641,8 +641,6 @@ on a new line! ""Wow!"", the masses cried";
             foreach (string bike in query)
                 Console.WriteLine(result);
 
-
-
         }
 
     } // End LearnCSharp class
@@ -657,7 +655,6 @@ on a new line! ""Wow!"", the masses cried";
             Console.WriteLine(obj.ToString());
         }
     }
-
 
     // DELEGATES AND EVENTS
     public class DelegateTest
@@ -694,7 +691,6 @@ on a new line! ""Wow!"", the masses cried";
             // composedInc will run Increment 3 times
             Console.WriteLine(composedInc());  // => 4
 
-
             // Subscribe to the event with the delegate
             MyEvent += new IncrementDelegate(Increment);
             MyEvent += new IncrementDelegate(Increment);
@@ -704,7 +700,6 @@ on a new line! ""Wow!"", the masses cried";
             Console.WriteLine(MyEvent());  // => 6
         }
     }
-
 
     // Class Declaration Syntax:
     // <public/private/protected/internal> class <class name>{
@@ -901,7 +896,6 @@ on a new line! ""Wow!"", the masses cried";
             // Within a static method, we only can reference static class members
             return BicyclesCreated > 9000;
         } // If your class only needs static members, consider marking the class itself as static.
-
 
     } // end class Bicycle
 
@@ -1347,3 +1341,4 @@ namespace Csharp7
 * [LINQ Pocket Reference](http://shop.oreilly.com/product/9780596519254.do)
 * [Windows Forms Programming in C#](http://www.amazon.com/Windows-Forms-Programming-Chris-Sells/dp/0321116208)
 * [freeCodeCamp - C# Tutorial for Beginners](https://www.youtube.com/watch?v=GhQdlIFylQ8)
+


### PR DESCRIPTION
## Summary

Removed 6 unnecessary consecutive blank lines in `csharp.md` that made code snippets harder to read.

Each instance had 2+ blank lines in a row, reduced to a single blank line while preserving logical section separation.

## Changes

- Line ~643: Removed 2 extra blank lines after `foreach` loop
- Line ~660: Removed extra blank line before DELEGATES AND EVENTS section
- Line ~696: Removed extra blank line before event subscription code
- Line ~707: Removed extra blank line before Class Declaration section
- Line ~904: Removed extra blank line before end of Bicycle class

No functional or content changes — purely whitespace cleanup.