### PR TITLE
[swift/zh] Fix syntax error in greet2 function example

### DIFF
--- a/zh-cn/swift.md
+++ b/zh-cn/swift.md
@@ -216,7 +216,7 @@ greet("Bob", day: "Tuesday")
 func greet2(_ requiredName: String, externalParamName localParamName: String) -> String {
     return "Hello \(requiredName), the day is \(localParamName)"
 }
-greet2(requiredName:"John", externalParamName: "Sunday")    // 调用时，使用命名参数来指定参数的值
+greet2("John", externalParamName: "Sunday")    // 调用时，使用命名参数来指定参数的值
 
 // 函数可以通过元组 (tuple) 返回多个值
 func getGasPrices() -> (Double, Double, Double) {


### PR DESCRIPTION
## Description
This PR fixes a syntax error in the Swift code example regarding argument labels (`_`). 

### The Problem
In the original example, the first parameter of `greet2` was defined with an underscore `_` to omit the external parameter name:
```swift
func greet2(_ requiredName: String, ...)
```
However, the subsequent invocation incorrectly provided the argument label requiredName:
```swift
greet2(requiredName: "John", ...) // This causes a compiler error
```

### The Fix
Updated the function call to match the definition by removing the omitted external parameter label 'requiredName:'.
```swift
greet2("John", externalParamName: "Sunday") // Now compiles successfully
```

Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New article/translation
- [ ] Documentation update
Checklist
- [ ] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
- [x] My lines are kept under 80 characters (per Style Guidelines).
- [x] Code examples are verified and accurate.
