### PR TITLE
[C++/en] Changed 'char const*' to 'const char*' because that is OBVIOUSLY how it SHOULD BE.

### DIFF
--- a/c++.md
+++ b/c++.md
@@ -96,7 +96,7 @@ int main()
 // C++ supports function overloading
 // provided each function takes different parameters.
 
-void print(char const* myString)
+void print(const char* myString)
 {
     printf("String %s\n", myString);
 }


### PR DESCRIPTION
Was disgusted when saw 'char const* myString' in a C++ coding guide. That looked so amateur and idiotic.  Maybe that's showing a reason that Linus Torvalds looks down on  C++.  Anyway, I kindly remedied that. Thanks for hosting LearnXinYMinutes!!!

- [ ] I solemnly swear that this is all original content of which I am the original author
- [ ] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [ ] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
