### PR TITLE
[C++] Corrected the circular pointer example

### DIFF
--- a/c++.md
+++ b/c++.md
@@ -866,8 +866,9 @@ void foo()
 // There will be always a reference, so it will be never destroyed!
 std::shared_ptr<Dog> doggo_one(new Dog());
 std::shared_ptr<Dog> doggo_two(new Dog());
-doggo_one = doggo_two; // p1 references p2
-doggo_two = doggo_one; // p2 references p1
+doggo_one->friend = doggo_two; // p1 references p2
+doggo_two->friend = doggo_one; // p2 references p1
+//Note that the 'friend' member of the 'Dog' type was a theoretical example and is not in prior 'Dog' class examples in this C++ guide.
 
 // There are several kinds of smart pointers.
 // The way you have to use them is always the same.


### PR DESCRIPTION
This is a more accurate example than the original that didn't point to a member var of the class:  
doggo_one->friend = doggo_two; 
// p1 references p2 
doggo_two->friend = doggo_one; 
// p2 references p1

- [ ] I solemnly swear that this is all original content of which I am the original author
- [ ] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [ ] Pull request touches only one file (or a set of logically related files with similar changes made)
- [ ] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [ ] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
