### PR TITLE
[javascript] Fix typo in javascript.md array splice documentation

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -193,7 +193,7 @@ myArray0.join(";"); // = "32;false;js;12;56;90"
 // Get subarray of elements from index 1 (include) to 4 (exclude)
 myArray0.slice(1,4); // = [false,"js",12]
 
-// Remove 4 elements starting from index 2, and insert there strings
+// Remove 4 elements starting from index 2, and insert three strings
 // "hi","wr" and "ld"; return removed subarray
 myArray0.splice(2,4,"hi","wr","ld"); // = ["js",12,56,90]
 // myArray0 === [32,false,"hi","wr","ld"]


### PR DESCRIPTION
Corrected typo on line 196: changed "there" to "three".

- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
