### PR TITLE
docs(it/c): fix occured typo in example comment

### DIFF
--- a/it/c.md
+++ b/it/c.md
@@ -402,7 +402,7 @@ int main (int argc, char** argv)
   printf("Error occurred at i = %d & j = %d.\n", i, j);
   /*
     https://ideone.com/GuPhd6
-    Questo stamperà l'errore 'Error occured at i=51 & j=99.'
+    Questo stamperà l'errore 'Error occurred at i=51 & j=99.'
   */
   /*
     È generalmente considerato una cattiva pratica farlo, 


### PR DESCRIPTION
## Summary
- Fixes a spelling mismatch in the Italian C tutorial: the sample `printf` uses `occurred`, but the surrounding comment said `occured`.

## Test plan
- [x] Confirmed the comment now matches the `printf` string on the line above


Made with [Cursor](https://cursor.com)