### PR TITLE
  [active-oberon/en] [active-oberon/uk] [active-oberon/ru] Add Active Oberon article

### DIFF
--- a/active-oberon.md
+++ b/active-oberon.md
@@ -1,0 +1,561 @@
+---
+name: Active Oberon
+filename: LearnActiveOberon.Mod
+contributors:
+    - ["Andrii Puhachenko", "https://github.com/andrqxa"]
+---
+
+**Active Oberon** is the last member of the Pascal / Modula-2 / Oberon family
+designed at ETH Zürich (1996-1998, by the group around Niklaus Wirth and
+Jürg Gutknecht). It keeps everything Oberon is known for — a grammar that fits
+on one page, modules with explicit exports, strong static typing and a garbage
+collector — and adds the feature it is named after: **active objects**.
+
+An object may carry its own thread (`BEGIN {ACTIVE}`), any block can be declared
+a critical section (`BEGIN {EXCLUSIVE}`), and `AWAIT(condition)` replaces
+condition variables. Concurrency is part of the language, not a library. On top
+of that the language grew operator overloading, enumerations, math (tensor)
+arrays with element-wise operators, and cells for hardware description.
+
+The whole [A2 operating
+system](https://en.wikipedia.org/wiki/A2_%28operating_system%29) — kernel,
+drivers, compiler, network stack and GUI — is written in Active Oberon, and A2
+is the natural place to try the language.
+
+The code below is accepted by the current Fox compiler of A2. Older
+A2 / Bluebottle sources use the historic type names (`LONGINT`, `LONGREAL`,
+`SHORTINT`) where modern code writes `SIGNED32`, `FLOAT64`, `SIGNED8`.
+
+```componentpascal
+(*  Comments look like this, and (* they nest *).  *)
+(** A comment with two stars is documentation and is picked up by the
+  documentation tools. *)
+
+(* A compilation unit is always a MODULE. Keywords are written in upper
+   case, identifiers are case sensitive, and the module name is repeated
+   after the final END. The file is normally named after the module. *)
+MODULE LearnActiveOberon;
+
+(* Case convention: the scanner reads keywords case insensitively, and the
+   extension of the file says which style is used. A file named X.Mod is
+   written with UPPER CASE keywords, a file named x.mod with lower case
+   ones, predeclared types and built-ins included:
+
+     module HelloLower;
+     import KernelLog;
+     procedure Do*;
+     var i: signed32;
+     begin
+       KernelLog.String("hi"); KernelLog.Ln
+     end Do;
+     end HelloLower.
+*)
+
+IMPORT
+  KernelLog,            (* writes to the system log *)
+  Streams,              (* Reader / Writer abstraction *)
+  Commands,             (* command context: input, output, arguments *)
+  Log := KernelLog;     (* an import may be renamed *)
+
+CONST
+  Max* = 100;           (* "*" exports the identifier *)
+  Greeting = "Hello";   (* no mark: visible inside this module only *)
+  EvenBits = {0, 2, 4, 6};                     (* a SET constant *)
+
+TYPE
+  Name* = ARRAY 32 OF CHAR;                    (* 0X terminated string *)
+  Handler* = PROCEDURE {DELEGATE} (n: SIGNED32);
+
+  Point* = RECORD
+    x*, y*: SIGNED32;
+  END;
+
+  Point3d* = RECORD (Point)                    (* record extension *)
+    z*: SIGNED32;
+  END;
+
+  Color* = ENUM Red*, Green*, Blue* END;       (* enumeration type *)
+
+  Vec2* = RECORD x*, y*: FLOAT64 END;
+
+VAR
+  counter-: SIGNED32;   (* "-" exports read-only: clients cannot assign *)
+  origin: Point;
+
+(* ------------------------------------------------------------------ *)
+(* Types, literals and operators                                       *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE Basics;
+VAR
+  b: BOOLEAN;
+  c: CHAR;
+  i8: SIGNED8; i16: SIGNED16; i32: SIGNED32; i64: SIGNED64;
+  u32: UNSIGNED32;
+  f32: FLOAT32; f64: FLOAT64;
+  z: COMPLEX64;
+  s: SET;                        (* small bit set *)
+  adr: ADDRESS; size: SIZE;      (* pointer sized integers *)
+  any: ANY;                      (* reference to any object *)
+BEGIN
+  (* INTEGER, REAL and SET are the default width variants; A2 code
+     usually spells the width out: SIGNED32, FLOAT64, SET32, ... *)
+  i32 := 42;  i32 := 2AH;  i32 := 0x2A;  i32 := 0b101010;
+  i32 := 1'000'000;              (* digit separators are allowed *)
+  i8 := -1; i16 := 1000; i64 := 1; u32 := 0FFFFFFFFH;
+  c := "A";  c := 41X;           (* character, hexadecimal character *)
+  f32 := 1.5;  f64 := 1.5E-3;
+  z := 1 + 2*IMAG;               (* IMAG is the imaginary unit *)
+  f64 := RE(z);  f64 := IM(z);
+
+  (* Arithmetic: + - * / DIV MOD, integer division is DIV *)
+  i32 := 7 DIV 2;  i32 := 7 MOD 2;  f64 := 7 / 2;
+  i32 := ABS(-3);  INC(i32);  DEC(i32, 2);
+
+  (* Relations: = # < <= > >= IN IS. Booleans: & OR ~ (not) *)
+  b := (i32 = 5) OR (i32 # 6) & ~(i32 < 0);
+
+  (* Sets *)
+  s := {0, 3, 5..7};  s := s + {1};  s := s * EvenBits;  s := s - {3};
+  b := 3 IN s;  INCL(s, 9);  EXCL(s, 0);
+
+  (* Conversions are explicit *)
+  i32 := ORD("A");  c := CHR(65);  f64 := i32;  i32 := ENTIER(f64);
+  adr := ADDRESSOF(i32);  size := SIZEOF(Point);
+
+  any := NIL;
+  ASSERT(i32 >= 0);              (* traps if the condition is FALSE *)
+END Basics;
+
+(* ------------------------------------------------------------------ *)
+(* Control flow                                                        *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE ControlFlow(n: SIGNED32): SIGNED32;
+VAR i, sum: SIGNED32; c: CHAR; color: Color;
+BEGIN
+  IF n < 0 THEN
+    n := -n
+  ELSIF n = 0 THEN
+    n := 1
+  ELSE
+    (* nothing *)
+  END;
+
+  c := "x";
+  CASE c OF
+      "a".."m": sum := 1
+    | "n".."z": sum := 2
+  ELSE
+    sum := 0
+  END;
+
+  color := Color.Green;          (* enumerators are qualified *)
+  IF color = Color.Green THEN sum := sum + 1 END;
+
+  WHILE n > 1 DO n := n DIV 2 END;
+
+  REPEAT INC(n) UNTIL n >= 4;
+
+  FOR i := 0 TO 10 BY 2 DO sum := sum + i END;
+
+  LOOP
+    INC(i);
+    IF i > 100 THEN EXIT END
+  END;
+
+  VAR local := sum + 1;          (* inline VAR declaration, type inferred *)
+  RETURN local
+END ControlFlow;
+
+(* ------------------------------------------------------------------ *)
+(* Arrays, strings, records and pointers                               *)
+(* ------------------------------------------------------------------ *)
+
+TYPE
+  IntArray* = POINTER TO ARRAY OF SIGNED32;    (* dynamic array *)
+  PointPtr* = POINTER TO Point;
+
+PROCEDURE Sum(CONST a: ARRAY OF SIGNED32): SIGNED32;   (* open array *)
+VAR i: SIZE; s: SIGNED32;                (* LEN returns a SIZE *)
+BEGIN
+  FOR i := 0 TO LEN(a) - 1 DO s := s + a[i] END;
+  RETURN s
+END Sum;
+
+PROCEDURE Swap(VAR a, b: SIGNED32);      (* VAR = by reference *)
+VAR t: SIGNED32;
+BEGIN t := a; a := b; b := t
+END Swap;
+
+PROCEDURE Aggregates;
+VAR
+  fixed: ARRAY 4 OF SIGNED32;
+  matrix: ARRAY 3, 3 OF FLOAT64;       (* multidimensional *)
+  dyn: IntArray;
+  name: Name;
+  p: Point3d;
+  pp: PointPtr;
+BEGIN
+  fixed[0] := 1; fixed[1] := 2;
+  matrix[1, 2] := 0.5;
+  NEW(dyn, 10);                        (* length known at run time *)
+  dyn[0] := Sum(fixed);
+  Swap(fixed[0], fixed[1]);
+
+  COPY(Greeting, name);                (* safe string copy *)
+  Strings0(name);
+
+  p.x := 1; p.y := 2; p.z := 3;        (* Point3d inherits x and y *)
+  origin.x := p.x; origin.y := p.y;
+
+  NEW(pp);                             (* garbage collected, no free *)
+  pp.x := 10;
+  pp := NIL;
+END Aggregates;
+
+PROCEDURE Strings0(VAR name: Name);
+VAR i: SIGNED32;
+BEGIN
+  i := 0;
+  WHILE name[i] # 0X DO INC(i) END;    (* strings end with 0X *)
+  Log.String(name); Log.Int(i, 1); Log.Ln
+END Strings0;
+
+(* ------------------------------------------------------------------ *)
+(* Procedures, delegates and exception handling                        *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE Outer(n: SIGNED32): SIGNED32;
+
+  PROCEDURE Inner(k: SIGNED32): SIGNED32;   (* nested, sees n *)
+  BEGIN RETURN k * n
+  END Inner;
+
+BEGIN
+  RETURN Inner(2)
+END Outer;
+
+PROCEDURE Print(n: SIGNED32);
+BEGIN Log.Int(n, 1); Log.Ln
+END Print;
+
+PROCEDURE UseDelegate;
+VAR h: Handler;
+BEGIN
+  h := Print;                          (* plain procedure *)
+  h(42);
+  (* A DELEGATE may also hold a method together with its object. *)
+END UseDelegate;
+
+PROCEDURE MayTrap(a, b: SIGNED32): SIGNED32;
+VAR result: SIGNED32;
+BEGIN
+  result := a DIV b;                   (* traps if b = 0 *)
+  RETURN result
+FINALLY                                  (* runs on a trap as well *)
+  RETURN 0
+END MayTrap;
+
+(* ------------------------------------------------------------------ *)
+(* Operator overloading                                                *)
+(* ------------------------------------------------------------------ *)
+
+OPERATOR "+"* (CONST a, b: Vec2): Vec2;
+VAR r: Vec2;
+BEGIN
+  r.x := a.x + b.x; r.y := a.y + b.y;
+  RETURN r
+END "+";
+
+(* ------------------------------------------------------------------ *)
+(* Objects: methods, constructor, inheritance                          *)
+(* ------------------------------------------------------------------ *)
+
+TYPE
+  Shape* = OBJECT
+  VAR
+    name-: Name;
+
+    PROCEDURE &Init*(CONST n: ARRAY OF CHAR);   (* constructor *)
+    BEGIN
+      COPY(n, name)
+    END Init;
+
+    PROCEDURE Area*(): FLOAT64;                 (* overridable *)
+    BEGIN
+      RETURN 0
+    END Area;
+
+    PROCEDURE Describe*;
+    BEGIN
+      Log.String(name); Log.String(" area=");
+      Log.Int(ENTIER(SELF.Area()), 1); Log.Ln   (* SELF = this *)
+    END Describe;
+  END Shape;
+
+  Circle* = OBJECT (Shape)                        (* single inheritance *)
+  VAR radius: FLOAT64;
+
+    PROCEDURE &InitCircle*(r: FLOAT64);
+    BEGIN
+      Init("circle");                         (* call inherited method *)
+      radius := r
+    END InitCircle;
+
+    PROCEDURE Area*(): FLOAT64;                 (* override *)
+    BEGIN
+      RETURN 3.14159 * radius * radius
+    END Area;
+  END Circle;
+
+PROCEDURE UseObjects;
+VAR s: Shape; c: Circle;
+BEGIN
+  NEW(c, 2.0);                (* NEW passes the constructor arguments *)
+  c.Describe;
+  s := c;                     (* a Circle is a Shape *)
+  s.Describe;                 (* dynamic dispatch: prints the circle area *)
+
+  IF s IS Circle THEN         (* run time type test *)
+    Log.String(s(Circle).name); Log.Ln    (* type guard *)
+  END;
+
+  WITH s: Circle DO           (* regional type guard *)
+    Log.Int(ENTIER(s.Area()), 1); Log.Ln
+  END
+END UseObjects;
+
+(* ------------------------------------------------------------------ *)
+(* Active objects: the reason the language is called *Active* Oberon   *)
+(* ------------------------------------------------------------------ *)
+
+TYPE
+  (* An object with a BEGIN {ACTIVE} body owns a thread that starts as
+     soon as the object is created. {EXCLUSIVE} turns an object into a
+     monitor: only one activity at a time may run inside such a block,
+     and AWAIT blocks until the condition becomes true. *)
+  Buffer* = OBJECT
+  VAR
+    data: ARRAY 16 OF SIGNED32;
+    head, tail, count: SIGNED32;
+    alive: BOOLEAN;
+
+    PROCEDURE &Init*;
+    BEGIN
+      head := 0; tail := 0; count := 0; alive := TRUE
+    END Init;
+
+    PROCEDURE Put*(x: SIGNED32);
+    BEGIN {EXCLUSIVE}
+      AWAIT(count < LEN(data));         (* wait until there is room *)
+      data[tail] := x;
+      tail := (tail + 1) MOD LEN(data);
+      INC(count)
+    END Put;
+
+    PROCEDURE Get*(): SIGNED32;
+    VAR x: SIGNED32;
+    BEGIN {EXCLUSIVE}
+      AWAIT(count > 0);                 (* wait for an element *)
+      x := data[head];
+      head := (head + 1) MOD LEN(data);
+      DEC(count);
+      RETURN x
+    END Get;
+
+    PROCEDURE Close*;
+    BEGIN {EXCLUSIVE}
+      alive := FALSE
+    END Close;
+
+  BEGIN {ACTIVE}                            (* the body is a thread *)
+    WHILE alive DO
+      Log.Int(SELF.Get(), 1); Log.Ln
+    END
+  END Buffer;
+
+PROCEDURE Producer*;
+VAR b: Buffer; i: SIGNED32;
+BEGIN
+  NEW(b);                                   (* the thread starts here *)
+  FOR i := 1 TO 5 DO b.Put(i) END;
+  b.Close
+END Producer;
+
+(* A whole procedure body can be a critical section, and a plain
+   BEGIN {EXCLUSIVE} ... END block may also appear inside a procedure. *)
+
+PROCEDURE Guarded(o: Buffer);
+BEGIN
+  BEGIN {EXCLUSIVE}
+    INC(counter)
+  END
+END Guarded;
+
+(* ------------------------------------------------------------------ *)
+(* Math arrays: array structured types with element wise operators     *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE MathArrays;
+VAR
+  v: ARRAY [*] OF FLOAT64;         (* one dimensional, open *)
+  m: ARRAY [*, *] OF FLOAT64;      (* two dimensional *)
+  t: ARRAY [?] OF FLOAT64;         (* tensor, any rank *)
+  w: ARRAY [3] OF FLOAT64;         (* fixed length *)
+  f: FLOAT64;
+BEGIN
+  NEW(v, 3); NEW(m, 3, 3);
+  v := [1.0, 2.0, 3.0];            (* array constructor *)
+  v := v .* v;                     (* element wise product *)
+  v := 2 * v;                      (* scalar broadcast *)
+  m := m + m;
+  v := m * v;                      (* matrix vector product *)
+  f := SUM(v);
+  f := v[1];  v[0..1] := v[1..2];  (* ranges and slices *)
+  Log.Int(LEN(v, 0), 1); Log.Ln;   (* length of dimension 0 *)
+  Log.Int(DIM(m), 1); Log.Ln       (* number of dimensions *)
+END MathArrays;
+
+(* ------------------------------------------------------------------ *)
+(* Commands: procedures callable from the A2 shell                     *)
+(* ------------------------------------------------------------------ *)
+
+(* An exported parameterless procedure, or one taking a
+   Commands.Context, can be started from the command line or from any
+   piece of text in the system by clicking on it. *)
+
+PROCEDURE Hello*(context: Commands.Context);
+VAR name: Name;
+BEGIN
+  context.arg.SkipWhitespace;
+  context.arg.String(name);                    (* read an argument *)
+  IF name = "" THEN COPY("world", name) END;
+  context.out.String(Greeting); context.out.String(", ");
+  context.out.String(name); context.out.String("!");
+  context.out.Ln;
+  context.out.Update                           (* flush the writer *)
+END Hello;
+
+PROCEDURE WriteTo(w: Streams.Writer);
+BEGIN
+  w.String("Streams.Writer works with files, network and screen");
+  w.Ln; w.Update
+END WriteTo;
+
+(* The module body runs once, when the module is loaded. *)
+BEGIN
+  counter := 0;
+  KernelLog.String("LearnActiveOberon loaded"); KernelLog.Ln
+END LearnActiveOberon.
+
+(* Text below the final dot is ignored by the compiler, so A2 sources
+   traditionally end with the commands that build and test the module.
+   In A2 you execute them by middle clicking on them:
+
+Compiler.Compile LearnActiveOberon.Mod ~
+LearnActiveOberon.Hello Active Oberon ~
+LearnActiveOberon.Producer ~
+System.Free LearnActiveOberon ~
+*)
+```
+
+## Modifiers in braces
+
+Almost every declaration — procedure, type, variable, parameter, statement
+block, cell — may carry a list of flags in braces. The parser accepts any
+identifier there, and the compiler rejects the ones it does not know.
+
+Concurrency (object bodies and statement blocks):
+
+* `{ACTIVE}` — the body runs as its own activity (thread), started when the
+  object is created.
+* `{EXCLUSIVE}` — the block is a critical section: at most one activity at a
+  time is inside any exclusive block of the object.
+* `{PRIORITY(n)}` — priority of the active body.
+* `{SAFE}` — the active body is restarted after a trap and resists
+  termination.
+* `{REALTIME}` — the body is a realtime activity and may only use operations
+  that are realtime safe.
+* `{UNCOOPERATIVE}` — the block does not take part in cooperative scheduling
+  (kernel and low level code).
+
+Object orientation:
+
+* `{ABSTRACT}` — record / object type or method without an implementation.
+* `{FINAL}` — the record cannot be extended, the method cannot be
+  overridden.
+* `{OVERRIDE}` — states explicitly that the method redefines an inherited
+  one (the compiler infers it otherwise).
+* `{DELEGATE}` — a procedure type whose values may also be a method bound to
+  its object.
+* `{DYNAMIC}` — operator dispatched at run time.
+
+Memory and safety:
+
+* `{UNTRACED}` — the pointer variable is not traced by the collector.
+* `{UNTRACKED}` — the statement block's local references are not tracked.
+* `{UNSAFE}` — `POINTER {UNSAFE} TO ...` is a raw pointer: compatible with
+  `ADDRESS`, no type guards, no checks.
+* `{UNCHECKED}` — the block is compiled without nil, index and stack checks.
+* `{DISPOSABLE}` — the pointer / object is released with `DISPOSE` instead of
+  by the collector.
+* `{ALIGNED(n)}` — align the symbol to `n` bytes.
+* `{OFFSET(n)}` — place the field or variable at a fixed offset.
+* `{MOVABLE}` — an `ADDRESS` parameter that may refer to memory the
+  collector moves.
+* `{REGISTER}` — keep the variable or parameter in a register if possible.
+
+Procedures and linking:
+
+* `{WINAPI}`, `{C}`, `{PlatformCC}` — calling convention of the procedure
+  (type).
+* `{INTERRUPT}` — the procedure is an interrupt handler.
+* `{NORETURN}` — the procedure never returns.
+* `{PLAIN}` — no activation frame, hence no local variables or parameters.
+* `{OPENING}` / `{CLOSING}` — link the procedure before all module bodies /
+  after them; both imply `PLAIN`.
+* `{ALIGNSTACK}` — align the stack when entering the procedure.
+* `{PCOFFSET(n)}` — program counter offset of the procedure type (back end).
+* `{Fingerprint=x}` — fix the symbol fingerprint instead of computing it.
+* `{TEST}` — mark a test procedure for the compiler's `--test` option.
+
+Active Cells (hardware description, FPGA back end) — properties of the
+generated cell or channel: `{DataMemorySize(n)}`, `{CodeMemorySize(n)}`,
+`{InstructionWidth(n)}`, `{ChannelWidth(n)}`, `{ChannelDepth(n)}`,
+`{Channels}`, `{Vector}`, `{FloatingPoint}`, `{NoMul}`,
+`{HasNonBlockingIO}`, `{FrequencyDivider(n)}`, `{Engine}`, `{TRM}`, `{TRMS}`,
+`{BaseMem}`, `{BaseDiv}`, `{Backend(s)}`, `{Runtime(s)}`.
+
+## Notable details
+
+* Identifiers are case sensitive. Keywords are read case insensitively, and
+  the file extension picks the style: `X.Mod` is written in UPPER CASE,
+  `x.mod` in lower case.
+* `*` after a declared name exports it, `-` exports it read-only.
+* There is no `free`: the system is garbage collected.
+* Every module can be loaded and unloaded at run time
+  (`System.Free Module ~`), which is how A2 is developed while it runs.
+* `SYSTEM` gives access to unsafe operations (`SYSTEM.GET`, `SYSTEM.PUT`,
+  `SYSTEM.VAL`, `SYSTEM.MOVE`), and `CODE ... END` embeds assembler.
+* Conditional compilation uses `#if ... #else ... #end` with symbols passed to
+  the compiler (`--define=UNIX,AMD64`).
+
+## Further reading
+
+* [t.me/A2OperatingSystem](https://t.me/A2OperatingSystem) — the main
+  community channel. It is mostly Russian speaking, but questions asked in
+  English are answered too.
+* [Active Oberon](https://en.wikipedia.org/wiki/Active_Oberon) and
+  [A2](https://en.wikipedia.org/wiki/A2_%28operating_system%29) on Wikipedia
+* [A2 project page at ETH Zürich](http://cas.inf.ethz.ch/projects/a2)
+* [Official A2 sources (ETH GitLab)](https://gitlab.inf.ethz.ch/felixf/oberon)
+* [a2oberon](https://gitlab.com/a25665725/a2oberon) — actively maintained
+  fork, branch `dev-andrii`, with the complete history imported from SVN;
+  `docs/` holds the Oberon Language Report, the quick start guide and the
+  concurrency framework paper
+* [minia2](https://github.com/active-oberon/minia2) — a small A2 that lets
+  you write console programs the way Go does
+* [a2-registry](https://active-oberon.github.io/a2-registry/) — descriptions
+  of the A2 modules
+* [oberon.org](https://oberon.org/en) — catalogue of Oberon resources

--- a/active-oberon.md
+++ b/active-oberon.md
@@ -554,8 +554,10 @@ generated cell or channel: `{DataMemorySize(n)}`, `{CodeMemorySize(n)}`,
   fork, branch `dev-andrii`, with the complete history imported from SVN;
   `docs/` holds the Oberon Language Report, the quick start guide and the
   concurrency framework paper
-* [minia2](https://github.com/active-oberon/minia2) — a small A2 that lets
-  you write console programs the way Go does
+* [minia2](https://github.com/active-oberon/minia2) — a Go style SDK:
+  compiler, language server and package manager in one Docker image. It
+  builds standalone Linux and Windows console programs, so you can write
+  Active Oberon without installing A2 at all
 * [a2-registry](https://active-oberon.github.io/a2-registry/) — descriptions
   of the A2 modules
 * [oberon.org](https://oberon.org/en) — catalogue of Oberon resources

--- a/ru/active-oberon.md
+++ b/ru/active-oberon.md
@@ -1,0 +1,567 @@
+---
+contributors:
+    - ["Andrii Puhachenko", "https://github.com/andrqxa"]
+translators:
+    - ["Andrii Puhachenko", "https://github.com/andrqxa"]
+---
+
+**Active Oberon** — последний представитель семейства Pascal / Modula-2 /
+Oberon, созданный в ETH Zürich (1996-1998, группой вокруг Никлауса Вирта и
+Юрга Гуткнехта). Он сохраняет всё, чем известен Oberon — грамматику, которая
+умещается на одну страницу, модули с явным экспортом, строгую статическую
+типизацию и сборщик мусора — и добавляет то, от чего происходит его название:
+**активные объекты**.
+
+У объекта может быть собственный поток (`BEGIN {ACTIVE}`), любой блок можно
+объявить критической секцией (`BEGIN {EXCLUSIVE}`), а `AWAIT(условие)`
+заменяет условные переменные. Параллелизм — часть языка, а не библиотека.
+Кроме того, язык получил перегрузку операторов, перечисления, математические
+(тензорные) массивы с поэлементными операциями и ячейки (cells) для описания
+аппаратуры.
+
+Вся [операционная система
+A2](https://ru.wikipedia.org/wiki/A2_%28операционная_система%29) — ядро,
+драйверы, компилятор, сетевой стек и графический интерфейс — написана на
+Active Oberon, и именно A2 — естественное место, чтобы попробовать язык.
+
+Приведённый ниже код принимает текущий компилятор Fox из A2. Более старые
+тексты A2 / Bluebottle используют исторические имена типов (`LONGINT`,
+`LONGREAL`, `SHORTINT`) там, где современный код пишет `SIGNED32`, `FLOAT64`,
+`SIGNED8`.
+
+```componentpascal
+(*  Комментарии выглядят так, и (* они вкладываются *).  *)
+(** Комментарий с двумя звёздочками — это документация, её собирают
+  инструменты документирования. *)
+
+(* Единица компиляции — всегда MODULE. Ключевые слова пишутся заглавными
+   буквами, идентификаторы чувствительны к регистру, а имя модуля
+   повторяется после последнего END. Файл обычно называют так же, как
+   модуль. *)
+MODULE LearnActiveOberon;
+
+(* Соглашение о регистре: сканер читает ключевые слова независимо от
+   регистра, а стиль файла задаётся его расширением. Файл X.Mod пишут
+   ЗАГЛАВНЫМИ буквами, файл x.mod — строчными, вместе с предобъявленными
+   типами и встроенными процедурами:
+
+     module HelloLower;
+     import KernelLog;
+     procedure Do*;
+     var i: signed32;
+     begin
+       KernelLog.String("hi"); KernelLog.Ln
+     end Do;
+     end HelloLower.
+*)
+
+IMPORT
+  KernelLog,            (* вывод в системный журнал *)
+  Streams,              (* абстракция Reader / Writer *)
+  Commands,             (* контекст команды: ввод, вывод, аргументы *)
+  Log := KernelLog;     (* импорт можно переименовать *)
+
+CONST
+  Max* = 100;           (* "*" экспортирует идентификатор *)
+  Greeting = "Hello";   (* без пометки: видно только в этом модуле *)
+  EvenBits = {0, 2, 4, 6};                  (* константа-множество *)
+
+TYPE
+  Name* = ARRAY 32 OF CHAR;                 (* строка, оканчивающаяся 0X *)
+  Handler* = PROCEDURE {DELEGATE} (n: SIGNED32);
+
+  Point* = RECORD
+    x*, y*: SIGNED32;
+  END;
+
+  Point3d* = RECORD (Point)                 (* расширение записи *)
+    z*: SIGNED32;
+  END;
+
+  Color* = ENUM Red*, Green*, Blue* END;    (* перечислимый тип *)
+
+  Vec2* = RECORD x*, y*: FLOAT64 END;
+
+VAR
+  counter-: SIGNED32;   (* "-" экспортирует только для чтения *)
+  origin: Point;
+
+(* ------------------------------------------------------------------ *)
+(* Типы, литералы и операции                                           *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE Basics;
+VAR
+  b: BOOLEAN;
+  c: CHAR;
+  i8: SIGNED8; i16: SIGNED16; i32: SIGNED32; i64: SIGNED64;
+  u32: UNSIGNED32;
+  f32: FLOAT32; f64: FLOAT64;
+  z: COMPLEX64;
+  s: SET;                        (* небольшое битовое множество *)
+  adr: ADDRESS; size: SIZE;      (* целые размером с указатель *)
+  any: ANY;                      (* ссылка на любой объект *)
+BEGIN
+  (* INTEGER, REAL и SET — варианты ширины по умолчанию; код A2 обычно
+     указывает ширину явно: SIGNED32, FLOAT64, SET32, ... *)
+  i32 := 42;  i32 := 2AH;  i32 := 0x2A;  i32 := 0b101010;
+  i32 := 1'000'000;              (* разделители разрядов разрешены *)
+  i8 := -1; i16 := 1000; i64 := 1; u32 := 0FFFFFFFFH;
+  c := "A";  c := 41X;           (* символ, шестнадцатеричный символ *)
+  f32 := 1.5;  f64 := 1.5E-3;
+  z := 1 + 2*IMAG;               (* IMAG — мнимая единица *)
+  f64 := RE(z);  f64 := IM(z);
+
+  (* Арифметика: + - * / DIV MOD, целочисленное деление — это DIV *)
+  i32 := 7 DIV 2;  i32 := 7 MOD 2;  f64 := 7 / 2;
+  i32 := ABS(-3);  INC(i32);  DEC(i32, 2);
+
+  (* Отношения: = # < <= > >= IN IS. Логические: & OR ~ (не) *)
+  b := (i32 = 5) OR (i32 # 6) & ~(i32 < 0);
+
+  (* Множества *)
+  s := {0, 3, 5..7};  s := s + {1};  s := s * EvenBits;  s := s - {3};
+  b := 3 IN s;  INCL(s, 9);  EXCL(s, 0);
+
+  (* Преобразования типов всегда явные *)
+  i32 := ORD("A");  c := CHR(65);  f64 := i32;  i32 := ENTIER(f64);
+  adr := ADDRESSOF(i32);  size := SIZEOF(Point);
+
+  any := NIL;
+  ASSERT(i32 >= 0);              (* ловушка (trap), если условие ложно *)
+END Basics;
+
+(* ------------------------------------------------------------------ *)
+(* Управление выполнением                                              *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE ControlFlow(n: SIGNED32): SIGNED32;
+VAR i, sum: SIGNED32; c: CHAR; color: Color;
+BEGIN
+  IF n < 0 THEN
+    n := -n
+  ELSIF n = 0 THEN
+    n := 1
+  ELSE
+    (* ничего *)
+  END;
+
+  c := "x";
+  CASE c OF
+      "a".."m": sum := 1
+    | "n".."z": sum := 2
+  ELSE
+    sum := 0
+  END;
+
+  color := Color.Green;          (* элементы перечисления квалифицированы *)
+  IF color = Color.Green THEN sum := sum + 1 END;
+
+  WHILE n > 1 DO n := n DIV 2 END;
+
+  REPEAT INC(n) UNTIL n >= 4;
+
+  FOR i := 0 TO 10 BY 2 DO sum := sum + i END;
+
+  LOOP
+    INC(i);
+    IF i > 100 THEN EXIT END
+  END;
+
+  VAR local := sum + 1;          (* объявление VAR внутри блока *)
+  RETURN local
+END ControlFlow;
+
+(* ------------------------------------------------------------------ *)
+(* Массивы, строки, записи и указатели                                 *)
+(* ------------------------------------------------------------------ *)
+
+TYPE
+  IntArray* = POINTER TO ARRAY OF SIGNED32;    (* динамический массив *)
+  PointPtr* = POINTER TO Point;
+
+PROCEDURE Sum(CONST a: ARRAY OF SIGNED32): SIGNED32;   (* открытый массив *)
+VAR i: SIZE; s: SIGNED32;                (* LEN возвращает SIZE *)
+BEGIN
+  FOR i := 0 TO LEN(a) - 1 DO s := s + a[i] END;
+  RETURN s
+END Sum;
+
+PROCEDURE Swap(VAR a, b: SIGNED32);      (* VAR = по ссылке *)
+VAR t: SIGNED32;
+BEGIN t := a; a := b; b := t
+END Swap;
+
+PROCEDURE Aggregates;
+VAR
+  fixed: ARRAY 4 OF SIGNED32;
+  matrix: ARRAY 3, 3 OF FLOAT64;       (* многомерный *)
+  dyn: IntArray;
+  name: Name;
+  p: Point3d;
+  pp: PointPtr;
+BEGIN
+  fixed[0] := 1; fixed[1] := 2;
+  matrix[1, 2] := 0.5;
+  NEW(dyn, 10);                        (* длина известна во время работы *)
+  dyn[0] := Sum(fixed);
+  Swap(fixed[0], fixed[1]);
+
+  COPY(Greeting, name);                (* безопасное копирование строки *)
+  Strings0(name);
+
+  p.x := 1; p.y := 2; p.z := 3;        (* Point3d наследует x и y *)
+  origin.x := p.x; origin.y := p.y;
+
+  NEW(pp);                             (* сборка мусора, освобождать не надо *)
+  pp.x := 10;
+  pp := NIL;
+END Aggregates;
+
+PROCEDURE Strings0(VAR name: Name);
+VAR i: SIGNED32;
+BEGIN
+  i := 0;
+  WHILE name[i] # 0X DO INC(i) END;    (* строки оканчиваются 0X *)
+  Log.String(name); Log.Int(i, 1); Log.Ln
+END Strings0;
+
+(* ------------------------------------------------------------------ *)
+(* Процедуры, делегаты и обработка ловушек                             *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE Outer(n: SIGNED32): SIGNED32;
+
+  PROCEDURE Inner(k: SIGNED32): SIGNED32;   (* вложенная, видит n *)
+  BEGIN RETURN k * n
+  END Inner;
+
+BEGIN
+  RETURN Inner(2)
+END Outer;
+
+PROCEDURE Print(n: SIGNED32);
+BEGIN Log.Int(n, 1); Log.Ln
+END Print;
+
+PROCEDURE UseDelegate;
+VAR h: Handler;
+BEGIN
+  h := Print;                          (* обычная процедура *)
+  h(42);
+  (* DELEGATE может хранить и метод вместе с его объектом. *)
+END UseDelegate;
+
+PROCEDURE MayTrap(a, b: SIGNED32): SIGNED32;
+VAR result: SIGNED32;
+BEGIN
+  result := a DIV b;                   (* ловушка, если b = 0 *)
+  RETURN result
+FINALLY                                (* выполняется и после ловушки *)
+  RETURN 0
+END MayTrap;
+
+(* ------------------------------------------------------------------ *)
+(* Перегрузка операторов                                               *)
+(* ------------------------------------------------------------------ *)
+
+OPERATOR "+"* (CONST a, b: Vec2): Vec2;
+VAR r: Vec2;
+BEGIN
+  r.x := a.x + b.x; r.y := a.y + b.y;
+  RETURN r
+END "+";
+
+(* ------------------------------------------------------------------ *)
+(* Объекты: методы, конструктор, наследование                          *)
+(* ------------------------------------------------------------------ *)
+
+TYPE
+  Shape* = OBJECT
+  VAR
+    name-: Name;
+
+    PROCEDURE &Init*(CONST n: ARRAY OF CHAR);   (* конструктор *)
+    BEGIN
+      COPY(n, name)
+    END Init;
+
+    PROCEDURE Area*(): FLOAT64;                 (* можно переопределить *)
+    BEGIN
+      RETURN 0
+    END Area;
+
+    PROCEDURE Describe*;
+    BEGIN
+      Log.String(name); Log.String(" area=");
+      Log.Int(ENTIER(SELF.Area()), 1); Log.Ln   (* SELF — этот объект *)
+    END Describe;
+  END Shape;
+
+  Circle* = OBJECT (Shape)                      (* одиночное наследование *)
+  VAR radius: FLOAT64;
+
+    PROCEDURE &InitCircle*(r: FLOAT64);
+    BEGIN
+      Init("circle");                           (* унаследованный метод *)
+      radius := r
+    END InitCircle;
+
+    PROCEDURE Area*(): FLOAT64;                 (* переопределение *)
+    BEGIN
+      RETURN 3.14159 * radius * radius
+    END Area;
+  END Circle;
+
+PROCEDURE UseObjects;
+VAR s: Shape; c: Circle;
+BEGIN
+  NEW(c, 2.0);                (* NEW передаёт аргументы конструктора *)
+  c.Describe;
+  s := c;                     (* Circle является Shape *)
+  s.Describe;                 (* динамическая диспетчеризация *)
+
+  IF s IS Circle THEN         (* проверка типа во время выполнения *)
+    Log.String(s(Circle).name); Log.Ln    (* охранник типа *)
+  END;
+
+  WITH s: Circle DO           (* охранник типа для целой области *)
+    Log.Int(ENTIER(s.Area()), 1); Log.Ln
+  END
+END UseObjects;
+
+(* ------------------------------------------------------------------ *)
+(* Активные объекты — то, за что язык назван *Active* Oberon           *)
+(* ------------------------------------------------------------------ *)
+
+TYPE
+  (* Объект с телом BEGIN {ACTIVE} имеет собственный поток, который
+     стартует сразу после создания объекта. {EXCLUSIVE} превращает
+     объект в монитор: внутри такого блока одновременно выполняется
+     только одна активность, а AWAIT блокирует до истинности условия. *)
+  Buffer* = OBJECT
+  VAR
+    data: ARRAY 16 OF SIGNED32;
+    head, tail, count: SIGNED32;
+    alive: BOOLEAN;
+
+    PROCEDURE &Init*;
+    BEGIN
+      head := 0; tail := 0; count := 0; alive := TRUE
+    END Init;
+
+    PROCEDURE Put*(x: SIGNED32);
+    BEGIN {EXCLUSIVE}
+      AWAIT(count < LEN(data));         (* ждать, пока появится место *)
+      data[tail] := x;
+      tail := (tail + 1) MOD LEN(data);
+      INC(count)
+    END Put;
+
+    PROCEDURE Get*(): SIGNED32;
+    VAR x: SIGNED32;
+    BEGIN {EXCLUSIVE}
+      AWAIT(count > 0);                 (* ждать элемент *)
+      x := data[head];
+      head := (head + 1) MOD LEN(data);
+      DEC(count);
+      RETURN x
+    END Get;
+
+    PROCEDURE Close*;
+    BEGIN {EXCLUSIVE}
+      alive := FALSE
+    END Close;
+
+  BEGIN {ACTIVE}                        (* тело объекта — это поток *)
+    WHILE alive DO
+      Log.Int(SELF.Get(), 1); Log.Ln
+    END
+  END Buffer;
+
+PROCEDURE Producer*;
+VAR b: Buffer; i: SIGNED32;
+BEGIN
+  NEW(b);                               (* здесь стартует поток *)
+  FOR i := 1 TO 5 DO b.Put(i) END;
+  b.Close
+END Producer;
+
+(* Критической секцией может быть целая процедура, а простой блок
+   BEGIN {EXCLUSIVE} ... END можно написать и внутри процедуры. *)
+
+PROCEDURE Guarded(o: Buffer);
+BEGIN
+  BEGIN {EXCLUSIVE}
+    INC(counter)
+  END
+END Guarded;
+
+(* ------------------------------------------------------------------ *)
+(* Математические массивы с поэлементными операциями                   *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE MathArrays;
+VAR
+  v: ARRAY [*] OF FLOAT64;         (* одномерный, открытый *)
+  m: ARRAY [*, *] OF FLOAT64;      (* двумерный *)
+  t: ARRAY [?] OF FLOAT64;         (* тензор произвольного ранга *)
+  w: ARRAY [3] OF FLOAT64;         (* фиксированная длина *)
+  f: FLOAT64;
+BEGIN
+  NEW(v, 3); NEW(m, 3, 3);
+  v := [1.0, 2.0, 3.0];            (* конструктор массива *)
+  v := v .* v;                     (* поэлементное произведение *)
+  v := 2 * v;                      (* скаляр распространяется на элементы *)
+  m := m + m;
+  v := m * v;                      (* произведение матрицы на вектор *)
+  f := SUM(v);
+  f := v[1];  v[0..1] := v[1..2];  (* диапазоны и срезы *)
+  Log.Int(LEN(v, 0), 1); Log.Ln;   (* длина нулевого измерения *)
+  Log.Int(DIM(m), 1); Log.Ln       (* количество измерений *)
+END MathArrays;
+
+(* ------------------------------------------------------------------ *)
+(* Команды: процедуры, запускаемые из оболочки A2                      *)
+(* ------------------------------------------------------------------ *)
+
+(* Экспортируемую процедуру без параметров или с параметром
+   Commands.Context можно запустить из командной строки или щелчком
+   по любому тексту в системе. *)
+
+PROCEDURE Hello*(context: Commands.Context);
+VAR name: Name;
+BEGIN
+  context.arg.SkipWhitespace;
+  context.arg.String(name);                    (* прочитать аргумент *)
+  IF name = "" THEN COPY("world", name) END;
+  context.out.String(Greeting); context.out.String(", ");
+  context.out.String(name); context.out.String("!");
+  context.out.Ln;
+  context.out.Update                           (* вытолкнуть буфер *)
+END Hello;
+
+PROCEDURE WriteTo(w: Streams.Writer);
+BEGIN
+  w.String("Streams.Writer works with files, network and screen");
+  w.Ln; w.Update
+END WriteTo;
+
+(* Тело модуля выполняется один раз, при загрузке модуля. *)
+BEGIN
+  counter := 0;
+  KernelLog.String("LearnActiveOberon loaded"); KernelLog.Ln
+END LearnActiveOberon.
+
+(* Текст после последней точки компилятор игнорирует, поэтому исходные
+   тексты A2 традиционно заканчиваются командами сборки и проверки
+   модуля. В A2 их выполняют щелчком средней кнопки мыши:
+
+Compiler.Compile LearnActiveOberon.Mod ~
+LearnActiveOberon.Hello Active Oberon ~
+LearnActiveOberon.Producer ~
+System.Free LearnActiveOberon ~
+*)
+```
+
+## Модификаторы в фигурных скобках
+
+Почти каждое объявление — процедура, тип, переменная, параметр, блок
+операторов, ячейка — может нести список флагов в фигурных скобках. Парсер
+принимает там любой идентификатор, а компилятор отвергает те, которых не
+знает.
+
+Параллелизм (тела объектов и блоки операторов):
+
+* `{ACTIVE}` — тело выполняется как собственная активность (поток), которая
+  стартует при создании объекта.
+* `{EXCLUSIVE}` — блок является критической секцией: в любом эксклюзивном
+  блоке объекта одновременно находится не более одной активности.
+* `{PRIORITY(n)}` — приоритет активного тела.
+* `{SAFE}` — активное тело перезапускается после ловушки и сопротивляется
+  завершению.
+* `{REALTIME}` — тело является активностью реального времени и может
+  использовать только операции, безопасные для реального времени.
+* `{UNCOOPERATIVE}` — блок не участвует в кооперативном планировании (ядро
+  и низкоуровневый код).
+
+Объектная ориентация:
+
+* `{ABSTRACT}` — тип-запись / объект или метод без реализации.
+* `{FINAL}` — запись нельзя расширить, метод нельзя переопределить.
+* `{OVERRIDE}` — явно указывает, что метод переопределяет унаследованный
+  (иначе компилятор выводит это сам).
+* `{DELEGATE}` — процедурный тип, значением которого может быть и метод
+  вместе с его объектом.
+* `{DYNAMIC}` — оператор, диспетчеризуемый во время выполнения.
+
+Память и безопасность:
+
+* `{UNTRACED}` — переменную-указатель не отслеживает сборщик мусора.
+* `{UNTRACKED}` — локальные ссылки блока не отслеживаются.
+* `{UNSAFE}` — `POINTER {UNSAFE} TO ...` — сырой указатель: совместим с
+  `ADDRESS`, без охранников типа и проверок.
+* `{UNCHECKED}` — блок компилируется без проверок NIL, границ и стека.
+* `{DISPOSABLE}` — указатель / объект освобождают через `DISPOSE`, а не
+  сборщиком мусора.
+* `{ALIGNED(n)}` — выровнять символ по n байтам.
+* `{OFFSET(n)}` — разместить поле или переменную по фиксированному смещению.
+* `{MOVABLE}` — параметр типа `ADDRESS`, который может указывать на память,
+  перемещаемую сборщиком мусора.
+* `{REGISTER}` — держать переменную или параметр в регистре, если возможно.
+
+Процедуры и компоновка:
+
+* `{WINAPI}`, `{C}`, `{PlatformCC}` — соглашение о вызове процедуры (типа).
+* `{INTERRUPT}` — процедура является обработчиком прерывания.
+* `{NORETURN}` — процедура никогда не возвращает управление.
+* `{PLAIN}` — без кадра активации, а значит без локальных переменных и
+  параметров.
+* `{OPENING}` / `{CLOSING}` — компоновать процедуру перед всеми телами
+  модулей / после них; оба флага подразумевают также `PLAIN`.
+* `{ALIGNSTACK}` — выровнять стек при входе в процедуру.
+* `{PCOFFSET(n)}` — смещение счётчика команд для процедурного типа
+  (генератор кода).
+* `{Fingerprint=x}` — зафиксировать отпечаток символа вместо вычисленного.
+* `{TEST}` — помечает тестовую процедуру для опции компилятора `--test`.
+
+Active Cells (описание аппаратуры, генерация для FPGA) — свойства
+создаваемой ячейки или канала: `{DataMemorySize(n)}`, `{CodeMemorySize(n)}`,
+`{InstructionWidth(n)}`, `{ChannelWidth(n)}`, `{ChannelDepth(n)}`,
+`{Channels}`, `{Vector}`, `{FloatingPoint}`, `{NoMul}`,
+`{HasNonBlockingIO}`, `{FrequencyDivider(n)}`, `{Engine}`, `{TRM}`, `{TRMS}`,
+`{BaseMem}`, `{BaseDiv}`, `{Backend(s)}`, `{Runtime(s)}`.
+
+## Важные мелочи
+
+* Идентификаторы чувствительны к регистру. Ключевые слова читаются независимо
+  от регистра, а стиль задаётся расширением файла: `X.Mod` пишут ЗАГЛАВНЫМИ
+  буквами, `x.mod` — строчными.
+* `*` после имени экспортирует его, `-` экспортирует только для чтения.
+* Нет `free`: система использует сборщик мусора.
+* Любой модуль можно загрузить и выгрузить во время работы системы
+  (`System.Free Module ~`) — именно так A2 разрабатывают, не перезапуская её.
+* `SYSTEM` даёт доступ к небезопасным операциям (`SYSTEM.GET`, `SYSTEM.PUT`,
+  `SYSTEM.VAL`, `SYSTEM.MOVE`), а `CODE ... END` встраивает ассемблер.
+* Условная компиляция: `#if ... #else ... #end` с символами, которые передают
+  компилятору (`--define=UNIX,AMD64`).
+
+## Что читать дальше
+
+* [t.me/A2OperatingSystem](https://t.me/A2OperatingSystem) — основной канал
+  сообщества. Он преимущественно русскоязычный, но на вопросы на английском
+  тоже отвечают.
+* [Active Oberon](https://ru.wikipedia.org/wiki/Active_Oberon) и
+  [A2](https://ru.wikipedia.org/wiki/A2_%28операционная_система%29) в
+  Википедии
+* [Страница проекта A2 в ETH Zürich](http://cas.inf.ethz.ch/projects/a2)
+* [Официальные тексты A2 (ETH GitLab)](https://gitlab.inf.ethz.ch/felixf/oberon)
+* [a2oberon](https://gitlab.com/a25665725/a2oberon) — активно развиваемый
+  форк, ветка `dev-andrii`, с полной историей, перенесённой из SVN; в
+  каталоге `docs/` лежат Oberon Language Report, краткое руководство и
+  статья о фреймворке параллелизма
+* [minia2](https://github.com/active-oberon/minia2) — небольшая A2, в
+  которой можно писать консольные программы в стиле Go
+* [a2-registry](https://active-oberon.github.io/a2-registry/) — описание
+  модулей A2
+* [oberon.org](https://oberon.org/en) — каталог ресурсов об Oberon

--- a/ru/active-oberon.md
+++ b/ru/active-oberon.md
@@ -560,8 +560,10 @@ Active Cells (описание аппаратуры, генерация для F
   форк, ветка `dev-andrii`, с полной историей, перенесённой из SVN; в
   каталоге `docs/` лежат Oberon Language Report, краткое руководство и
   статья о фреймворке параллелизма
-* [minia2](https://github.com/active-oberon/minia2) — небольшая A2, в
-  которой можно писать консольные программы в стиле Go
+* [minia2](https://github.com/active-oberon/minia2) — SDK в стиле Go:
+  компилятор, языковой сервер и менеджер пакетов в одном образе Docker.
+  Собирает самодостаточные консольные программы для Linux и Windows, так
+  что писать на Active Oberon можно вообще без установки A2
 * [a2-registry](https://active-oberon.github.io/a2-registry/) — описание
   модулей A2
 * [oberon.org](https://oberon.org/en) — каталог ресурсов об Oberon

--- a/uk/active-oberon.md
+++ b/uk/active-oberon.md
@@ -556,8 +556,10 @@ Active Cells (опис апаратури, генерація для FPGA) — �
   розвивають, гілка `dev-andrii`, з повною історією, перенесеною з SVN;
   у каталозі `docs/` лежать Oberon Language Report, короткий посібник і
   стаття про фреймворк паралелізму
-* [minia2](https://github.com/active-oberon/minia2) — невелика A2, у якій
-  можна писати консольні програми в стилі Go
+* [minia2](https://github.com/active-oberon/minia2) — SDK у стилі Go:
+  компілятор, мовний сервер і менеджер пакетів в одному образі Docker.
+  Збирає самодостатні консольні програми для Linux і Windows, тож писати
+  мовою Active Oberon можна взагалі без встановлення A2
 * [a2-registry](https://active-oberon.github.io/a2-registry/) — опис
   модулів A2
 * [oberon.org](https://oberon.org/en) — каталог ресурсів про Oberon

--- a/uk/active-oberon.md
+++ b/uk/active-oberon.md
@@ -1,0 +1,563 @@
+---
+contributors:
+    - ["Andrii Puhachenko", "https://github.com/andrqxa"]
+translators:
+    - ["Andrii Puhachenko", "https://github.com/andrqxa"]
+---
+
+**Active Oberon** — останній представник родини Pascal / Modula-2 / Oberon,
+створений у ETH Zürich (1996-1998, групою навколо Ніклауса Вірта та
+Юрга Гуткнехта). Він зберігає все, чим відомий Oberon — граматику, що
+вміщається на одну сторінку, модулі з явним експортом, сувору статичну
+типізацію та збирач сміття — і додає те, від чого походить його назва:
+**активні об'єкти**.
+
+Об'єкт може мати власний потік (`BEGIN {ACTIVE}`), будь-який блок можна
+оголосити критичною секцією (`BEGIN {EXCLUSIVE}`), а `AWAIT(умова)` замінює
+умовні змінні. Паралелізм є частиною мови, а не бібліотекою. Крім того, мова
+отримала перевизначення операторів, переліки, математичні (тензорні) масиви
+з поелементними операторами та комірки (cells) для опису апаратури.
+
+Уся [операційна система
+A2](https://uk.wikipedia.org/wiki/A2_%28операційна_система%29) — ядро, драйвери,
+компілятор, мережевий стек і графічний інтерфейс — написана мовою Active
+Oberon, і саме A2 є природним місцем, щоб спробувати цю мову.
+
+Наведений нижче код приймає поточний компілятор Fox із A2. Старіші тексти
+A2 / Bluebottle використовують історичні назви типів (`LONGINT`, `LONGREAL`,
+`SHORTINT`) там, де сучасний код пише `SIGNED32`, `FLOAT64`, `SIGNED8`.
+
+```componentpascal
+(*  Коментарі виглядають так, і (* вони вкладаються *).  *)
+(** Коментар із двома зірочками — це документація, її збирають
+  документаційні інструменти. *)
+
+(* Одиниця компіляції — це завжди MODULE. Ключові слова пишуть великими
+   літерами, ідентифікатори чутливі до регістру, а ім'я модуля
+   повторюється після останнього END. Файл зазвичай називають так само,
+   як модуль. *)
+MODULE LearnActiveOberon;
+
+(* Домовленість про регістр: сканер читає ключові слова незалежно від
+   регістру, а стиль файлу визначає його розширення. Файл X.Mod пишуть
+   ВЕЛИКИМИ літерами, файл x.mod — малими, разом із наперед оголошеними
+   типами та вбудованими процедурами:
+
+     module HelloLower;
+     import KernelLog;
+     procedure Do*;
+     var i: signed32;
+     begin
+       KernelLog.String("hi"); KernelLog.Ln
+     end Do;
+     end HelloLower.
+*)
+
+IMPORT
+  KernelLog,            (* вивід у системний журнал *)
+  Streams,              (* абстракція Reader / Writer *)
+  Commands,             (* контекст команди: ввід, вивід, аргументи *)
+  Log := KernelLog;     (* імпорт можна перейменувати *)
+
+CONST
+  Max* = 100;           (* "*" експортує ідентифікатор *)
+  Greeting = "Hello";   (* без позначки: видно лише в цьому модулі *)
+  EvenBits = {0, 2, 4, 6};                  (* константа-множина *)
+
+TYPE
+  Name* = ARRAY 32 OF CHAR;                 (* рядок, що завершується 0X *)
+  Handler* = PROCEDURE {DELEGATE} (n: SIGNED32);
+
+  Point* = RECORD
+    x*, y*: SIGNED32;
+  END;
+
+  Point3d* = RECORD (Point)                 (* розширення запису *)
+    z*: SIGNED32;
+  END;
+
+  Color* = ENUM Red*, Green*, Blue* END;    (* перелічуваний тип *)
+
+  Vec2* = RECORD x*, y*: FLOAT64 END;
+
+VAR
+  counter-: SIGNED32;   (* "-" експортує лише для читання *)
+  origin: Point;
+
+(* ------------------------------------------------------------------ *)
+(* Типи, літерали та оператори                                         *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE Basics;
+VAR
+  b: BOOLEAN;
+  c: CHAR;
+  i8: SIGNED8; i16: SIGNED16; i32: SIGNED32; i64: SIGNED64;
+  u32: UNSIGNED32;
+  f32: FLOAT32; f64: FLOAT64;
+  z: COMPLEX64;
+  s: SET;                        (* невелика бітова множина *)
+  adr: ADDRESS; size: SIZE;      (* цілі розміру вказівника *)
+  any: ANY;                      (* посилання на будь-який об'єкт *)
+BEGIN
+  (* INTEGER, REAL і SET — варіанти типової ширини; код A2 зазвичай
+     вказує ширину явно: SIGNED32, FLOAT64, SET32, ... *)
+  i32 := 42;  i32 := 2AH;  i32 := 0x2A;  i32 := 0b101010;
+  i32 := 1'000'000;              (* роздільники розрядів дозволені *)
+  i8 := -1; i16 := 1000; i64 := 1; u32 := 0FFFFFFFFH;
+  c := "A";  c := 41X;           (* символ, шістнадцятковий символ *)
+  f32 := 1.5;  f64 := 1.5E-3;
+  z := 1 + 2*IMAG;               (* IMAG — уявна одиниця *)
+  f64 := RE(z);  f64 := IM(z);
+
+  (* Арифметика: + - * / DIV MOD, цілочисельне ділення — це DIV *)
+  i32 := 7 DIV 2;  i32 := 7 MOD 2;  f64 := 7 / 2;
+  i32 := ABS(-3);  INC(i32);  DEC(i32, 2);
+
+  (* Відношення: = # < <= > >= IN IS. Логічні: & OR ~ (не) *)
+  b := (i32 = 5) OR (i32 # 6) & ~(i32 < 0);
+
+  (* Множини *)
+  s := {0, 3, 5..7};  s := s + {1};  s := s * EvenBits;  s := s - {3};
+  b := 3 IN s;  INCL(s, 9);  EXCL(s, 0);
+
+  (* Перетворення типів завжди явні *)
+  i32 := ORD("A");  c := CHR(65);  f64 := i32;  i32 := ENTIER(f64);
+  adr := ADDRESSOF(i32);  size := SIZEOF(Point);
+
+  any := NIL;
+  ASSERT(i32 >= 0);              (* пастка (trap), якщо умова хибна *)
+END Basics;
+
+(* ------------------------------------------------------------------ *)
+(* Керування виконанням                                                *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE ControlFlow(n: SIGNED32): SIGNED32;
+VAR i, sum: SIGNED32; c: CHAR; color: Color;
+BEGIN
+  IF n < 0 THEN
+    n := -n
+  ELSIF n = 0 THEN
+    n := 1
+  ELSE
+    (* нічого *)
+  END;
+
+  c := "x";
+  CASE c OF
+      "a".."m": sum := 1
+    | "n".."z": sum := 2
+  ELSE
+    sum := 0
+  END;
+
+  color := Color.Green;          (* елементи переліку кваліфіковані *)
+  IF color = Color.Green THEN sum := sum + 1 END;
+
+  WHILE n > 1 DO n := n DIV 2 END;
+
+  REPEAT INC(n) UNTIL n >= 4;
+
+  FOR i := 0 TO 10 BY 2 DO sum := sum + i END;
+
+  LOOP
+    INC(i);
+    IF i > 100 THEN EXIT END
+  END;
+
+  VAR local := sum + 1;          (* оголошення VAR усередині блоку *)
+  RETURN local
+END ControlFlow;
+
+(* ------------------------------------------------------------------ *)
+(* Масиви, рядки, записи та вказівники                                 *)
+(* ------------------------------------------------------------------ *)
+
+TYPE
+  IntArray* = POINTER TO ARRAY OF SIGNED32;    (* динамічний масив *)
+  PointPtr* = POINTER TO Point;
+
+PROCEDURE Sum(CONST a: ARRAY OF SIGNED32): SIGNED32;   (* відкритий масив *)
+VAR i: SIZE; s: SIGNED32;                (* LEN повертає SIZE *)
+BEGIN
+  FOR i := 0 TO LEN(a) - 1 DO s := s + a[i] END;
+  RETURN s
+END Sum;
+
+PROCEDURE Swap(VAR a, b: SIGNED32);      (* VAR = за посиланням *)
+VAR t: SIGNED32;
+BEGIN t := a; a := b; b := t
+END Swap;
+
+PROCEDURE Aggregates;
+VAR
+  fixed: ARRAY 4 OF SIGNED32;
+  matrix: ARRAY 3, 3 OF FLOAT64;       (* багатовимірний *)
+  dyn: IntArray;
+  name: Name;
+  p: Point3d;
+  pp: PointPtr;
+BEGIN
+  fixed[0] := 1; fixed[1] := 2;
+  matrix[1, 2] := 0.5;
+  NEW(dyn, 10);                        (* довжина відома під час виконання *)
+  dyn[0] := Sum(fixed);
+  Swap(fixed[0], fixed[1]);
+
+  COPY(Greeting, name);                (* безпечне копіювання рядка *)
+  Strings0(name);
+
+  p.x := 1; p.y := 2; p.z := 3;        (* Point3d успадковує x та y *)
+  origin.x := p.x; origin.y := p.y;
+
+  NEW(pp);                             (* збирач сміття, звільняти не треба *)
+  pp.x := 10;
+  pp := NIL;
+END Aggregates;
+
+PROCEDURE Strings0(VAR name: Name);
+VAR i: SIGNED32;
+BEGIN
+  i := 0;
+  WHILE name[i] # 0X DO INC(i) END;    (* рядки завершуються 0X *)
+  Log.String(name); Log.Int(i, 1); Log.Ln
+END Strings0;
+
+(* ------------------------------------------------------------------ *)
+(* Процедури, делегати та обробка пасток                               *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE Outer(n: SIGNED32): SIGNED32;
+
+  PROCEDURE Inner(k: SIGNED32): SIGNED32;   (* вкладена, бачить n *)
+  BEGIN RETURN k * n
+  END Inner;
+
+BEGIN
+  RETURN Inner(2)
+END Outer;
+
+PROCEDURE Print(n: SIGNED32);
+BEGIN Log.Int(n, 1); Log.Ln
+END Print;
+
+PROCEDURE UseDelegate;
+VAR h: Handler;
+BEGIN
+  h := Print;                          (* звичайна процедура *)
+  h(42);
+  (* DELEGATE може містити й метод разом з його об'єктом. *)
+END UseDelegate;
+
+PROCEDURE MayTrap(a, b: SIGNED32): SIGNED32;
+VAR result: SIGNED32;
+BEGIN
+  result := a DIV b;                   (* пастка, якщо b = 0 *)
+  RETURN result
+FINALLY                                (* виконується також після пастки *)
+  RETURN 0
+END MayTrap;
+
+(* ------------------------------------------------------------------ *)
+(* Перевизначення операторів                                           *)
+(* ------------------------------------------------------------------ *)
+
+OPERATOR "+"* (CONST a, b: Vec2): Vec2;
+VAR r: Vec2;
+BEGIN
+  r.x := a.x + b.x; r.y := a.y + b.y;
+  RETURN r
+END "+";
+
+(* ------------------------------------------------------------------ *)
+(* Об'єкти: методи, конструктор, успадкування                          *)
+(* ------------------------------------------------------------------ *)
+
+TYPE
+  Shape* = OBJECT
+  VAR
+    name-: Name;
+
+    PROCEDURE &Init*(CONST n: ARRAY OF CHAR);   (* конструктор *)
+    BEGIN
+      COPY(n, name)
+    END Init;
+
+    PROCEDURE Area*(): FLOAT64;                 (* можна перевизначити *)
+    BEGIN
+      RETURN 0
+    END Area;
+
+    PROCEDURE Describe*;
+    BEGIN
+      Log.String(name); Log.String(" area=");
+      Log.Int(ENTIER(SELF.Area()), 1); Log.Ln   (* SELF — цей об'єкт *)
+    END Describe;
+  END Shape;
+
+  Circle* = OBJECT (Shape)                      (* одиничне успадкування *)
+  VAR radius: FLOAT64;
+
+    PROCEDURE &InitCircle*(r: FLOAT64);
+    BEGIN
+      Init("circle");                           (* успадкований метод *)
+      radius := r
+    END InitCircle;
+
+    PROCEDURE Area*(): FLOAT64;                 (* перевизначення *)
+    BEGIN
+      RETURN 3.14159 * radius * radius
+    END Area;
+  END Circle;
+
+PROCEDURE UseObjects;
+VAR s: Shape; c: Circle;
+BEGIN
+  NEW(c, 2.0);                (* NEW передає аргументи конструктора *)
+  c.Describe;
+  s := c;                     (* Circle є Shape *)
+  s.Describe;                 (* динамічна диспетчеризація *)
+
+  IF s IS Circle THEN         (* перевірка типу під час виконання *)
+    Log.String(s(Circle).name); Log.Ln    (* охоронець типу *)
+  END;
+
+  WITH s: Circle DO           (* охоронець типу для цілої області *)
+    Log.Int(ENTIER(s.Area()), 1); Log.Ln
+  END
+END UseObjects;
+
+(* ------------------------------------------------------------------ *)
+(* Активні об'єкти — те, за що мову названо *Active* Oberon            *)
+(* ------------------------------------------------------------------ *)
+
+TYPE
+  (* Об'єкт із тілом BEGIN {ACTIVE} має власний потік, який стартує
+     одразу після створення об'єкта. {EXCLUSIVE} перетворює об'єкт на
+     монітор: усередині такого блоку одночасно виконується лише одна
+     активність, а AWAIT блокує до виконання умови. *)
+  Buffer* = OBJECT
+  VAR
+    data: ARRAY 16 OF SIGNED32;
+    head, tail, count: SIGNED32;
+    alive: BOOLEAN;
+
+    PROCEDURE &Init*;
+    BEGIN
+      head := 0; tail := 0; count := 0; alive := TRUE
+    END Init;
+
+    PROCEDURE Put*(x: SIGNED32);
+    BEGIN {EXCLUSIVE}
+      AWAIT(count < LEN(data));         (* чекати, доки з'явиться місце *)
+      data[tail] := x;
+      tail := (tail + 1) MOD LEN(data);
+      INC(count)
+    END Put;
+
+    PROCEDURE Get*(): SIGNED32;
+    VAR x: SIGNED32;
+    BEGIN {EXCLUSIVE}
+      AWAIT(count > 0);                 (* чекати на елемент *)
+      x := data[head];
+      head := (head + 1) MOD LEN(data);
+      DEC(count);
+      RETURN x
+    END Get;
+
+    PROCEDURE Close*;
+    BEGIN {EXCLUSIVE}
+      alive := FALSE
+    END Close;
+
+  BEGIN {ACTIVE}                        (* тіло об'єкта — це потік *)
+    WHILE alive DO
+      Log.Int(SELF.Get(), 1); Log.Ln
+    END
+  END Buffer;
+
+PROCEDURE Producer*;
+VAR b: Buffer; i: SIGNED32;
+BEGIN
+  NEW(b);                               (* тут стартує потік *)
+  FOR i := 1 TO 5 DO b.Put(i) END;
+  b.Close
+END Producer;
+
+(* Тілом критичної секції може бути ціла процедура, а простий блок
+   BEGIN {EXCLUSIVE} ... END можна написати й усередині процедури. *)
+
+PROCEDURE Guarded(o: Buffer);
+BEGIN
+  BEGIN {EXCLUSIVE}
+    INC(counter)
+  END
+END Guarded;
+
+(* ------------------------------------------------------------------ *)
+(* Математичні масиви з поелементними операторами                      *)
+(* ------------------------------------------------------------------ *)
+
+PROCEDURE MathArrays;
+VAR
+  v: ARRAY [*] OF FLOAT64;         (* одновимірний, відкритий *)
+  m: ARRAY [*, *] OF FLOAT64;      (* двовимірний *)
+  t: ARRAY [?] OF FLOAT64;         (* тензор довільного рангу *)
+  w: ARRAY [3] OF FLOAT64;         (* фіксована довжина *)
+  f: FLOAT64;
+BEGIN
+  NEW(v, 3); NEW(m, 3, 3);
+  v := [1.0, 2.0, 3.0];            (* конструктор масиву *)
+  v := v .* v;                     (* поелементний добуток *)
+  v := 2 * v;                      (* скаляр поширюється на всі елементи *)
+  m := m + m;
+  v := m * v;                      (* добуток матриці на вектор *)
+  f := SUM(v);
+  f := v[1];  v[0..1] := v[1..2];  (* діапазони та зрізи *)
+  Log.Int(LEN(v, 0), 1); Log.Ln;   (* довжина нульового виміру *)
+  Log.Int(DIM(m), 1); Log.Ln       (* кількість вимірів *)
+END MathArrays;
+
+(* ------------------------------------------------------------------ *)
+(* Команди: процедури, які запускають з оболонки A2                    *)
+(* ------------------------------------------------------------------ *)
+
+(* Експортовану процедуру без параметрів або з параметром
+   Commands.Context можна запустити з командного рядка чи клацанням
+   по будь-якому тексту в системі. *)
+
+PROCEDURE Hello*(context: Commands.Context);
+VAR name: Name;
+BEGIN
+  context.arg.SkipWhitespace;
+  context.arg.String(name);                    (* прочитати аргумент *)
+  IF name = "" THEN COPY("world", name) END;
+  context.out.String(Greeting); context.out.String(", ");
+  context.out.String(name); context.out.String("!");
+  context.out.Ln;
+  context.out.Update                           (* виштовхнути буфер *)
+END Hello;
+
+PROCEDURE WriteTo(w: Streams.Writer);
+BEGIN
+  w.String("Streams.Writer works with files, network and screen");
+  w.Ln; w.Update
+END WriteTo;
+
+(* Тіло модуля виконується один раз, під час завантаження модуля. *)
+BEGIN
+  counter := 0;
+  KernelLog.String("LearnActiveOberon loaded"); KernelLog.Ln
+END LearnActiveOberon.
+
+(* Текст після останньої крапки компілятор ігнорує, тому вихідні тексти
+   A2 традиційно завершують командами для збирання й перевірки модуля.
+   В A2 їх виконують клацанням середньою кнопкою миші:
+
+Compiler.Compile LearnActiveOberon.Mod ~
+LearnActiveOberon.Hello Active Oberon ~
+LearnActiveOberon.Producer ~
+System.Free LearnActiveOberon ~
+*)
+```
+
+## Модифікатори у фігурних дужках
+
+Майже кожне оголошення — процедура, тип, змінна, параметр, блок операторів,
+комірка — може мати список прапорців у фігурних дужках. Синтаксичний
+аналізатор приймає там будь-який ідентифікатор, а компілятор відхиляє ті,
+яких не знає.
+
+Паралелізм (тіла об'єктів і блоки операторів):
+
+* `{ACTIVE}` — тіло виконується як власна активність (потік), що стартує
+  після створення об'єкта.
+* `{EXCLUSIVE}` — блок є критичною секцією: у будь-якому ексклюзивному блоці
+  об'єкта одночасно перебуває не більш ніж одна активність.
+* `{PRIORITY(n)}` — пріоритет активного тіла.
+* `{SAFE}` — активне тіло перезапускається після пастки й опирається
+  завершенню.
+* `{REALTIME}` — тіло є активністю реального часу й може використовувати
+  лише операції, безпечні для реального часу.
+* `{UNCOOPERATIVE}` — блок не бере участі в кооперативному плануванні
+  (ядро та низькорівневий код).
+
+Об'єктна орієнтація:
+
+* `{ABSTRACT}` — тип-запис / об'єкт або метод без реалізації.
+* `{FINAL}` — запис не можна розширити, метод не можна перевизначити.
+* `{OVERRIDE}` — явно вказує, що метод перевизначає успадкований (інакше
+  компілятор виводить це сам).
+* `{DELEGATE}` — процедурний тип, значенням якого може бути й метод разом
+  з його об'єктом.
+* `{DYNAMIC}` — оператор, що диспетчеризується під час виконання.
+
+Пам'ять і безпека:
+
+* `{UNTRACED}` — змінну-вказівник не відстежує збирач сміття.
+* `{UNTRACKED}` — локальні посилання блоку не відстежуються.
+* `{UNSAFE}` — `POINTER {UNSAFE} TO ...` — сирий вказівник: сумісний з
+  `ADDRESS`, без охоронців типу й перевірок.
+* `{UNCHECKED}` — блок компілюється без перевірок NIL, меж та стека.
+* `{DISPOSABLE}` — вказівник / об'єкт звільняють через `DISPOSE`, а не
+  збирачем сміття.
+* `{ALIGNED(n)}` — вирівняти символ на n байтів.
+* `{OFFSET(n)}` — розмістити поле або змінну за фіксованим зміщенням.
+* `{MOVABLE}` — параметр типу `ADDRESS`, що може вказувати на пам'ять, яку
+  збирач сміття переміщує.
+* `{REGISTER}` — тримати змінну чи параметр у регістрі, якщо можливо.
+
+Процедури та компонування:
+
+* `{WINAPI}`, `{C}`, `{PlatformCC}` — угода про виклик процедури (типу).
+* `{INTERRUPT}` — процедура є обробником переривання.
+* `{NORETURN}` — процедура ніколи не повертає керування.
+* `{PLAIN}` — без кадру активації, тож без локальних змінних і параметрів.
+* `{OPENING}` / `{CLOSING}` — компонувати процедуру перед усіма тілами
+  модулів / після них; обидва прапорці означають також `PLAIN`.
+* `{ALIGNSTACK}` — вирівняти стек під час входу в процедуру.
+* `{PCOFFSET(n)}` — зміщення лічильника команд для процедурного типу
+  (генератор коду).
+* `{Fingerprint=x}` — зафіксувати відбиток символу замість обчисленого.
+* `{TEST}` — позначає тестову процедуру для опції компілятора `--test`.
+
+Active Cells (опис апаратури, генерація для FPGA) — властивості створюваної
+комірки чи каналу: `{DataMemorySize(n)}`, `{CodeMemorySize(n)}`,
+`{InstructionWidth(n)}`, `{ChannelWidth(n)}`, `{ChannelDepth(n)}`,
+`{Channels}`, `{Vector}`, `{FloatingPoint}`, `{NoMul}`,
+`{HasNonBlockingIO}`, `{FrequencyDivider(n)}`, `{Engine}`, `{TRM}`, `{TRMS}`,
+`{BaseMem}`, `{BaseDiv}`, `{Backend(s)}`, `{Runtime(s)}`.
+
+## Важливі дрібниці
+
+* Ідентифікатори чутливі до регістру. Ключові слова читаються незалежно від
+  регістру, а стиль задає розширення файлу: `X.Mod` пишуть ВЕЛИКИМИ
+  літерами, `x.mod` — малими.
+* `*` після імені експортує його, `-` експортує лише для читання.
+* Немає `free`: система має збирач сміття.
+* Будь-який модуль можна завантажити й вивантажити під час роботи системи
+  (`System.Free Module ~`) — саме так A2 розробляють, не перезапускаючи її.
+* `SYSTEM` дає доступ до небезпечних операцій (`SYSTEM.GET`, `SYSTEM.PUT`,
+  `SYSTEM.VAL`, `SYSTEM.MOVE`), а `CODE ... END` вбудовує асемблер.
+* Умовна компіляція: `#if ... #else ... #end` із символами, які передають
+  компіляторові (`--define=UNIX,AMD64`).
+
+## Що читати далі
+
+* [t.me/A2OperatingSystem](https://t.me/A2OperatingSystem) — головний канал
+  спільноти. Він переважно російськомовний, але на питання англійською теж
+  відповідають.
+* [Active Oberon](https://uk.wikipedia.org/wiki/Active_Oberon) та
+  [A2](https://uk.wikipedia.org/wiki/A2_%28операційна_система%29) у Вікіпедії
+* [Сторінка проєкту A2 в ETH Zürich](http://cas.inf.ethz.ch/projects/a2)
+* [Офіційні тексти A2 (ETH GitLab)](https://gitlab.inf.ethz.ch/felixf/oberon)
+* [a2oberon](https://gitlab.com/a25665725/a2oberon) — форк, який активно
+  розвивають, гілка `dev-andrii`, з повною історією, перенесеною з SVN;
+  у каталозі `docs/` лежать Oberon Language Report, короткий посібник і
+  стаття про фреймворк паралелізму
+* [minia2](https://github.com/active-oberon/minia2) — невелика A2, у якій
+  можна писати консольні програми в стилі Go
+* [a2-registry](https://active-oberon.github.io/a2-registry/) — опис
+  модулів A2
+* [oberon.org](https://oberon.org/en) — каталог ресурсів про Oberon


### PR DESCRIPTION
  Adds an article on Active Oberon, in English, Ukrainian and Russian:

  - active-oberon.md
  - uk/active-oberon.md
  - ru/active-oberon.md

  Why

  Active Oberon is the last member of the Pascal / Modula-2 / Oberon family designed at ETH Zürich (1996–1998, the group
  around Niklaus Wirth and Jürg Gutknecht) and the implementation language of the A2 operating system — kernel, drivers,
  compiler, network stack and GUI are all written in it. The site covers Pascal but nothing from the Oberon side of the
  family, and Active Oberon is the branch where concurrency is part of the language: an object may own a thread (BEGIN
  {ACTIVE}), any block can be a critical section (BEGIN {EXCLUSIVE}), and AWAIT(condition) replaces condition variables.

  What the article covers

  Modules and export marks (*, -), types and literals, control flow, arrays and strings, records, pointers, procedures and
  delegates, FINALLY, operator overloading, objects with constructors and inheritance, active objects, math (tensor) arrays,
  commands callable from the A2 shell, the {...} modifier vocabulary, and the convention that Module.Mod uses upper case
  keywords while module.mod uses lower case.

  Verification

  - The whole code sample compiles with the current Fox compiler of A2 (Compiler.Compile on the code extracted from each of
  the three files).
  - Language surface checked against the ETH Oberon Language Report and the compiler sources (FoxScanner.Mod, FoxParser.Mod,
  FoxGlobal.Mod), which is the authority where the two disagree.
  - Lines are under 80 characters; lint/encoding.sh and lint/frontmatter.py pass; no NBSP / ZWSP / CR.

  Syntax highlighting

  The fences say componentpascal, the closest lexer Pygments currently ships. A dedicated Active Oberon lexer is in review
  upstream — pygments/pygments#3237. Once it is released I will send a follow-up changing the fences to activeoberon.

  Happy to split this into one pull request per language if that is easier to review.
