### PR TITLE
[swift/en] Fix availability check syntax for macOS

### DIFF
--- a/swift.md
+++ b/swift.md
@@ -863,7 +863,7 @@ println()
 //  #error("This would be a compile-time error")
 
 //Availability Conditions
-if #available(iOSMac 10.15, *) {
+if #available(macOS 10.15, *) {
     // macOS 10.15 is available, you can use it here
 } else {
     // macOS 10.15 is not available, use alternate APIs


### PR DESCRIPTION
- [x] I solemnly swear that this is all original content of which I am the original author
- [x] Pull request title is prepended with `[language/lang-code]` (example `[python/fr]` for Python in French or `[java]` for multiple Java translations)
- [x] Pull request touches only one file (or a set of logically related files with similar changes made)
- [x] Content changes are aimed at *intermediate to experienced programmers* (this is a poor format for explaining fundamental programming concepts)
- [x] If you've changed any part of the YAML Frontmatter, make sure it is formatted according to [CONTRIBUTING.md](https://github.com/adambard/learnxinyminutes-docs/blob/master/CONTRIBUTING.md)
